### PR TITLE
Feature/255 update daobot execute funding round

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cross-fetch": "^3.1.4",
     "dotenv": "^8.2.0",
     "googleapis": "^71.0.0",
+    "moment": "^2.29.1",
     "node-fetch": "^2.6.1",
     "node-metamask": "^1.1.2",
     "typescript": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@snapshot-labs/snapshot.js": "github:snapshot-labs/snapshot.js#master",
     "airtable": "^0.11.0",
     "axios": "^0.21.1",
+    "coingecko-api": "^1.0.10",
     "cross-fetch": "^3.1.4",
     "dotenv": "^8.2.0",
     "googleapis": "^71.0.0",

--- a/src/airtable/airtable_utils.js
+++ b/src/airtable/airtable_utils.js
@@ -78,4 +78,21 @@ const updateProposalRecords = async (records) => {
     ))
 }
 
-module.exports = {getRoundsSelectQuery, getProposalsSelectQuery, updateProposalRecords, sumSnapshotVotesToAirtable}
+const updateRoundRecord = async (record) => {
+    await fetch(`https://api.airtable.com/v0/${process.env.AIRTABLE_BASEID}/Funding Rounds`, {
+        method: "patch", // make sure it is a "PATCH request"
+        headers: {
+            Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`, // API key
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({records: record}),
+    })
+    .then((res) => {
+        console.log('Response from Airtable: ', res.status)
+    })
+    .catch((err) => {
+        console.log(err);
+    })
+}
+
+module.exports = {getRoundsSelectQuery, getProposalsSelectQuery, updateProposalRecords, updateRoundRecord, sumSnapshotVotesToAirtable}

--- a/src/airtable/process_airtable_funding_round_complete.js
+++ b/src/airtable/process_airtable_funding_round_complete.js
@@ -104,6 +104,8 @@ const processFundingRoundComplete = async (curRoundNumber) => {
 
     await updateValues(oAuth, sheetName, 'A1:H' + (gsheetRows.length + 1), gsheetRows)
     console.log('\n[%s]\nDumped [%s] rows to Gsheets', (new Date()).toString(), Object.entries(gsheetRows).length)
+
+    return earmarkedResults.length + generalResults.length + partiallyFundedResults.length
 }
 
 module.exports = {processFundingRoundComplete};

--- a/src/airtable/process_airtable_funding_round_complete.js
+++ b/src/airtable/process_airtable_funding_round_complete.js
@@ -2,8 +2,8 @@ global['fetch'] = require('cross-fetch');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const {getProposalsSelectQuery, getRoundsSelectQuery, updateProposalRecords} = require('./airtable_utils')
-const {getCurrentRound} = require('./rounds/funding_rounds')
+const {getProposalsSelectQuery, getRoundsSelectQuery, updateProposalRecords, updateRoundRecord} = require('./airtable_utils')
+const {RoundState, getCurrentRound} = require('./rounds/funding_rounds')
 const {initOAuthToken} = require('../gsheets/gsheets')
 const {getValues, addSheet, updateValues} = require('../gsheets/gsheets_utils')
 const {getWinningProposals, calculateFinalResults, getDownvotedProposals, dumpResultsToGSheet} = require('./rounds/funding_rounds')
@@ -11,103 +11,126 @@ const {getWinningProposals, calculateFinalResults, getDownvotedProposals, dumpRe
 const main = async () => {
     const curRound = await getCurrentRound()
     const curRoundNumber = curRound.get('Round')
+    const curRoundState = curRound.get('Round State')
 
-    // Step 1 - Identify all winning and downvoted proposals
-    // const activeProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
-    const activeProposals = await getProposalsSelectQuery(`{Round} = "${curRoundNumber}"`)
-    const downvotedProposals = getDownvotedProposals(activeProposals)
-    const winningProposals = getWinningProposals(activeProposals, curRoundNumber)
-    const finalResults = calculateFinalResults(winningProposals, curRound)
+    const lastRoundNumber = parseInt(curRoundNumber,10) - 1
+    let lastRound = await getRoundsSelectQuery(`{Round} = ${lastRoundNumber}`)
+    lastRound = lastRound[0]
+    const lastRoundState = lastRound.get('Round State')
+    const lastRoundVotingEnds = lastRound.get('Voting Ends')
+    const now = new Date().toISOString().split('T')[0]
 
-    let airtableRows = []
-    airtableRows = airtableRows.concat(downvotedProposals)
-    airtableRows = airtableRows.concat(finalResults.earmarkedResults.winningProposals)
-    airtableRows = airtableRows.concat(finalResults.generalResults.winningProposals)
-    airtableRows = airtableRows.concat(finalResults.partiallyFunded)
-    airtableRows = airtableRows.concat(finalResults.notFunded)
+    if( curRoundState === undefined && lastRoundState === RoundState.Voting && lastRoundVotingEnds <= now ) {
+        // Step 1 - Identify all winning and downvoted proposals
+        // const activeProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
+        const activeProposals = await getProposalsSelectQuery(`{Round} = "${curRoundNumber}"`)
+        const downvotedProposals = getDownvotedProposals(activeProposals)
+        const winningProposals = getWinningProposals(activeProposals, curRoundNumber)
+        const finalResults = calculateFinalResults(winningProposals, curRound)
 
-    airtableRows = airtableRows.map(p => {
-        return {
-            id: p['id'],
-            fields: {
-                'Proposal State': p.get('Proposal State'),
-                'USD Granted': p.get('USD Granted'),
-                'OCEAN Requested': p.get('OCEAN Requested'),
-                'OCEAN Granted': p.get('OCEAN Granted')
+        let airtableRows = []
+        airtableRows = airtableRows.concat(downvotedProposals)
+        airtableRows = airtableRows.concat(finalResults.earmarkedResults.winningProposals)
+        airtableRows = airtableRows.concat(finalResults.generalResults.winningProposals)
+        airtableRows = airtableRows.concat(finalResults.partiallyFunded)
+        airtableRows = airtableRows.concat(finalResults.notFunded)
+
+        airtableRows = airtableRows.map(p => {
+            return {
+                id: p['id'],
+                fields: {
+                    'Proposal State': p.get('Proposal State'),
+                    'USD Granted': p.get('USD Granted'),
+                    'OCEAN Requested': p.get('OCEAN Requested'),
+                    'OCEAN Granted': p.get('OCEAN Granted')
+                }
             }
+        })
+
+        // Step 2 - Update all DB records
+        await updateProposalRecords(airtableRows)
+        console.log('\n[%s]\nUpdated [%s] rows to Airtable', (new Date()).toString(), Object.entries(airtableRows).length)
+
+        // Step 3 - Dump all results to a flattened list
+        let downvotedResults = await dumpResultsToGSheet(downvotedProposals)
+        let earmarkedResults = await dumpResultsToGSheet(finalResults.earmarkedResults.winningProposals)
+        let generalResults = await dumpResultsToGSheet(finalResults.generalResults.winningProposals)
+        let partiallyFundedResults = await dumpResultsToGSheet(finalResults.partiallyFunded)
+        let notFundedResults = await dumpResultsToGSheet(finalResults.notFunded)
+
+        // Finally, write to gsheets
+        const oAuth = await initOAuthToken()
+
+        let sheetName = "Round" + curRoundNumber + "FinalResults"
+
+        // Get the sheet, otherwise create it
+        let sheet = await getValues(oAuth, sheetName, 'A1:B3')
+        if (sheet === undefined) {
+            sheet = await addSheet(oAuth, sheetName)
+            console.log("Created new sheet [%s].", sheetName)
         }
-    })
 
-    // Step 2 - Update all DB records
-    await updateProposalRecords(airtableRows)
-    console.log('\n[%s]\nUpdated [%s] rows to Airtable', (new Date()).toString(), Object.entries(airtableRows).length)
+        let gsheetRows = []
 
-    // Step 3 - Dump all results to a flattened list
-    let downvotedResults = await dumpResultsToGSheet(downvotedProposals)
-    let earmarkedResults = await dumpResultsToGSheet(finalResults.earmarkedResults.winningProposals)
-    let generalResults = await dumpResultsToGSheet(finalResults.generalResults.winningProposals)
-    let partiallyFundedResults = await dumpResultsToGSheet(finalResults.partiallyFunded)
-    let notFundedResults = await dumpResultsToGSheet(finalResults.notFunded)
+        // Flatten results onto gsheetRows
+        earmarkedResults.splice(0, 0, ['Earmarked Winners'])
+        earmarkedResults.push([''])
+        generalResults.splice(0, 0, ['General Winners'])
+        generalResults.push([''])
+        partiallyFundedResults.splice(0, 0, ['Partially Funded'])
+        partiallyFundedResults.push([''])
+        notFundedResults.splice(0, 0, ['Proposals that could not be funded'])
+        notFundedResults.push([''])
+        downvotedResults.splice(0, 0, ['Downvoted Proposals'])
+        downvotedResults.push([''])
+        gsheetRows = gsheetRows.concat(earmarkedResults)
+        gsheetRows = gsheetRows.concat(generalResults)
+        gsheetRows = gsheetRows.concat(partiallyFundedResults)
+        gsheetRows = gsheetRows.concat(notFundedResults)
+        gsheetRows = gsheetRows.concat(downvotedResults)
 
-    // Finally, write to gsheets
-    const oAuth = await initOAuthToken()
-
-    let sheetName = "Round" + curRoundNumber + "FinalResults"
-
-    // Get the sheet, otherwise create it
-    let sheet = await getValues(oAuth, sheetName, 'A1:B3')
-    if (sheet === undefined) {
-        sheet = await addSheet(oAuth, sheetName)
-        console.log("Created new sheet [%s].", sheetName)
-    }
-
-    let gsheetRows = []
-
-    // Flatten results onto gsheetRows
-    earmarkedResults.splice(0,0, ['Earmarked Winners'])
-    earmarkedResults.push([''])
-    generalResults.splice(0, 0, ['General Winners'])
-    generalResults.push([''])
-    partiallyFundedResults.splice(0, 0, ['Partially Funded'])
-    partiallyFundedResults.push([''])
-    notFundedResults.splice(0, 0, ['Proposals that could not be funded'])
-    notFundedResults.push([''])
-    downvotedResults.splice(0, 0, ['Downvoted Proposals'])
-    downvotedResults.push([''])
-    gsheetRows = gsheetRows.concat(earmarkedResults)
-    gsheetRows = gsheetRows.concat(generalResults)
-    gsheetRows = gsheetRows.concat(partiallyFundedResults)
-    gsheetRows = gsheetRows.concat(notFundedResults)
-    gsheetRows = gsheetRows.concat(downvotedResults)
-
-    let oceanUSD = curRound.get('OCEAN Price')
-    // 2x Rows => Header & Summed results
-    let burnedFunds = [
-        [
-            'Earmarked USD Burned', '','General USD Burned', '', 'Total USD Burned'
-        ],
-        [
-            finalResults.earmarkedResults.fundsLeft,
-            '',
-            finalResults.generalResults.fundsLeft,
-            '',
-            finalResults.earmarkedResults.fundsLeft+finalResults.generalResults.fundsLeft
-        ],
-        [
-        'Earmarked OCEAN Burned', '','General OCEAN Burned', '', 'Total OCEAN Burned'
-        ],
-        [
-            finalResults.earmarkedResults.fundsLeft / oceanUSD,
-            '',
-            finalResults.generalResults.fundsLeft / oceanUSD,
-            '',
-            (finalResults.earmarkedResults.fundsLeft+finalResults.generalResults.fundsLeft) / oceanUSD
+        let oceanUSD = curRound.get('OCEAN Price')
+        // 2x Rows => Header & Summed results
+        let burnedFunds = [
+            [
+                'Earmarked USD Burned', '', 'General USD Burned', '', 'Total USD Burned'
+            ],
+            [
+                finalResults.earmarkedResults.fundsLeft,
+                '',
+                finalResults.generalResults.fundsLeft,
+                '',
+                finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft
+            ],
+            [
+                'Earmarked OCEAN Burned', '', 'General OCEAN Burned', '', 'Total OCEAN Burned'
+            ],
+            [
+                finalResults.earmarkedResults.fundsLeft / oceanUSD,
+                '',
+                finalResults.generalResults.fundsLeft / oceanUSD,
+                '',
+                (finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft) / oceanUSD
+            ]
         ]
-    ]
-    gsheetRows = gsheetRows.concat(burnedFunds)
+        gsheetRows = gsheetRows.concat(burnedFunds)
 
-    await updateValues(oAuth, sheetName, 'A1:H' + (gsheetRows.length+1), gsheetRows)
-    console.log('\n[%s]\nDumped [%s] rows to Gsheets', (new Date()).toString(), Object.entries(gsheetRows).length)
+        await updateValues(oAuth, sheetName, 'A1:H' + (gsheetRows.length + 1), gsheetRows)
+        console.log('\n[%s]\nDumped [%s] rows to Gsheets', (new Date()).toString(), Object.entries(gsheetRows).length)
+
+        const roundUpdate = [{
+            id: lastRound['id'],
+            fields: {
+                'Round State': RoundState.Ended,
+            }
+        },{
+            id: curRound['id'],
+            fields: {
+                'Round State': RoundState.Started,
+            }
+        }]
+        updateRoundRecord(roundUpdate)
+    }
 }
 
 main()

--- a/src/airtable/process_airtable_funding_round_complete.js
+++ b/src/airtable/process_airtable_funding_round_complete.js
@@ -2,135 +2,108 @@ global['fetch'] = require('cross-fetch');
 const dotenv = require('dotenv');
 dotenv.config();
 
-const {getProposalsSelectQuery, getRoundsSelectQuery, updateProposalRecords, updateRoundRecord} = require('./airtable_utils')
-const {RoundState, getCurrentRound} = require('./rounds/funding_rounds')
+const {getProposalsSelectQuery, updateProposalRecords} = require('./airtable_utils')
 const {initOAuthToken} = require('../gsheets/gsheets')
 const {getValues, addSheet, updateValues} = require('../gsheets/gsheets_utils')
 const {getWinningProposals, calculateFinalResults, getDownvotedProposals, dumpResultsToGSheet} = require('./rounds/funding_rounds')
 
-const main = async () => {
-    const curRound = await getCurrentRound()
-    const curRoundNumber = curRound.get('Round')
-    const curRoundState = curRound.get('Round State')
+const processFundingRoundComplete = async (curRoundNumber) => {
+    // Step 1 - Identify all winning and downvoted proposals
+    // const activeProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
+    const activeProposals = await getProposalsSelectQuery(`{Round} = "${curRoundNumber}"`)
+    const downvotedProposals = getDownvotedProposals(activeProposals)
+    const winningProposals = getWinningProposals(activeProposals, curRoundNumber)
+    const finalResults = calculateFinalResults(winningProposals, curRound)
 
-    const lastRoundNumber = parseInt(curRoundNumber,10) - 1
-    let lastRound = await getRoundsSelectQuery(`{Round} = ${lastRoundNumber}`)
-    lastRound = lastRound[0]
-    const lastRoundState = lastRound.get('Round State')
-    const lastRoundVotingEnds = lastRound.get('Voting Ends')
-    const now = new Date().toISOString().split('T')[0]
+    let airtableRows = []
+    airtableRows = airtableRows.concat(downvotedProposals)
+    airtableRows = airtableRows.concat(finalResults.earmarkedResults.winningProposals)
+    airtableRows = airtableRows.concat(finalResults.generalResults.winningProposals)
+    airtableRows = airtableRows.concat(finalResults.partiallyFunded)
+    airtableRows = airtableRows.concat(finalResults.notFunded)
 
-    if( curRoundState === undefined && lastRoundState === RoundState.Voting && lastRoundVotingEnds <= now ) {
-        // Step 1 - Identify all winning and downvoted proposals
-        // const activeProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
-        const activeProposals = await getProposalsSelectQuery(`{Round} = "${curRoundNumber}"`)
-        const downvotedProposals = getDownvotedProposals(activeProposals)
-        const winningProposals = getWinningProposals(activeProposals, curRoundNumber)
-        const finalResults = calculateFinalResults(winningProposals, curRound)
-
-        let airtableRows = []
-        airtableRows = airtableRows.concat(downvotedProposals)
-        airtableRows = airtableRows.concat(finalResults.earmarkedResults.winningProposals)
-        airtableRows = airtableRows.concat(finalResults.generalResults.winningProposals)
-        airtableRows = airtableRows.concat(finalResults.partiallyFunded)
-        airtableRows = airtableRows.concat(finalResults.notFunded)
-
-        airtableRows = airtableRows.map(p => {
-            return {
-                id: p['id'],
-                fields: {
-                    'Proposal State': p.get('Proposal State'),
-                    'USD Granted': p.get('USD Granted'),
-                    'OCEAN Requested': p.get('OCEAN Requested'),
-                    'OCEAN Granted': p.get('OCEAN Granted')
-                }
+    airtableRows = airtableRows.map(p => {
+        return {
+            id: p['id'],
+            fields: {
+                'Proposal State': p.get('Proposal State'),
+                'USD Granted': p.get('USD Granted'),
+                'OCEAN Requested': p.get('OCEAN Requested'),
+                'OCEAN Granted': p.get('OCEAN Granted')
             }
-        })
-
-        // Step 2 - Update all DB records
-        await updateProposalRecords(airtableRows)
-        console.log('\n[%s]\nUpdated [%s] rows to Airtable', (new Date()).toString(), Object.entries(airtableRows).length)
-
-        // Step 3 - Dump all results to a flattened list
-        let downvotedResults = await dumpResultsToGSheet(downvotedProposals)
-        let earmarkedResults = await dumpResultsToGSheet(finalResults.earmarkedResults.winningProposals)
-        let generalResults = await dumpResultsToGSheet(finalResults.generalResults.winningProposals)
-        let partiallyFundedResults = await dumpResultsToGSheet(finalResults.partiallyFunded)
-        let notFundedResults = await dumpResultsToGSheet(finalResults.notFunded)
-
-        // Finally, write to gsheets
-        const oAuth = await initOAuthToken()
-
-        let sheetName = "Round" + curRoundNumber + "FinalResults"
-
-        // Get the sheet, otherwise create it
-        let sheet = await getValues(oAuth, sheetName, 'A1:B3')
-        if (sheet === undefined) {
-            sheet = await addSheet(oAuth, sheetName)
-            console.log("Created new sheet [%s].", sheetName)
         }
+    })
 
-        let gsheetRows = []
+    // Step 2 - Update all DB records
+    await updateProposalRecords(airtableRows)
+    console.log('\n[%s]\nUpdated [%s] rows to Airtable', (new Date()).toString(), Object.entries(airtableRows).length)
 
-        // Flatten results onto gsheetRows
-        earmarkedResults.splice(0, 0, ['Earmarked Winners'])
-        earmarkedResults.push([''])
-        generalResults.splice(0, 0, ['General Winners'])
-        generalResults.push([''])
-        partiallyFundedResults.splice(0, 0, ['Partially Funded'])
-        partiallyFundedResults.push([''])
-        notFundedResults.splice(0, 0, ['Proposals that could not be funded'])
-        notFundedResults.push([''])
-        downvotedResults.splice(0, 0, ['Downvoted Proposals'])
-        downvotedResults.push([''])
-        gsheetRows = gsheetRows.concat(earmarkedResults)
-        gsheetRows = gsheetRows.concat(generalResults)
-        gsheetRows = gsheetRows.concat(partiallyFundedResults)
-        gsheetRows = gsheetRows.concat(notFundedResults)
-        gsheetRows = gsheetRows.concat(downvotedResults)
+    // Step 3 - Dump all results to a flattened list
+    let downvotedResults = await dumpResultsToGSheet(downvotedProposals)
+    let earmarkedResults = await dumpResultsToGSheet(finalResults.earmarkedResults.winningProposals)
+    let generalResults = await dumpResultsToGSheet(finalResults.generalResults.winningProposals)
+    let partiallyFundedResults = await dumpResultsToGSheet(finalResults.partiallyFunded)
+    let notFundedResults = await dumpResultsToGSheet(finalResults.notFunded)
 
-        let oceanUSD = curRound.get('OCEAN Price')
-        // 2x Rows => Header & Summed results
-        let burnedFunds = [
-            [
-                'Earmarked USD Burned', '', 'General USD Burned', '', 'Total USD Burned'
-            ],
-            [
-                finalResults.earmarkedResults.fundsLeft,
-                '',
-                finalResults.generalResults.fundsLeft,
-                '',
-                finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft
-            ],
-            [
-                'Earmarked OCEAN Burned', '', 'General OCEAN Burned', '', 'Total OCEAN Burned'
-            ],
-            [
-                finalResults.earmarkedResults.fundsLeft / oceanUSD,
-                '',
-                finalResults.generalResults.fundsLeft / oceanUSD,
-                '',
-                (finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft) / oceanUSD
-            ]
-        ]
-        gsheetRows = gsheetRows.concat(burnedFunds)
+    // Finally, write to gsheets
+    const oAuth = await initOAuthToken()
 
-        await updateValues(oAuth, sheetName, 'A1:H' + (gsheetRows.length + 1), gsheetRows)
-        console.log('\n[%s]\nDumped [%s] rows to Gsheets', (new Date()).toString(), Object.entries(gsheetRows).length)
+    let sheetName = "Round" + curRoundNumber + "FinalResults"
 
-        const roundUpdate = [{
-            id: lastRound['id'],
-            fields: {
-                'Round State': RoundState.Ended,
-            }
-        },{
-            id: curRound['id'],
-            fields: {
-                'Round State': RoundState.Started,
-            }
-        }]
-        updateRoundRecord(roundUpdate)
+    // Get the sheet, otherwise create it
+    let sheet = await getValues(oAuth, sheetName, 'A1:B3')
+    if (sheet === undefined) {
+        sheet = await addSheet(oAuth, sheetName)
+        console.log("Created new sheet [%s].", sheetName)
     }
+
+    let gsheetRows = []
+
+    // Flatten results onto gsheetRows
+    earmarkedResults.splice(0, 0, ['Earmarked Winners'])
+    earmarkedResults.push([''])
+    generalResults.splice(0, 0, ['General Winners'])
+    generalResults.push([''])
+    partiallyFundedResults.splice(0, 0, ['Partially Funded'])
+    partiallyFundedResults.push([''])
+    notFundedResults.splice(0, 0, ['Proposals that could not be funded'])
+    notFundedResults.push([''])
+    downvotedResults.splice(0, 0, ['Downvoted Proposals'])
+    downvotedResults.push([''])
+    gsheetRows = gsheetRows.concat(earmarkedResults)
+    gsheetRows = gsheetRows.concat(generalResults)
+    gsheetRows = gsheetRows.concat(partiallyFundedResults)
+    gsheetRows = gsheetRows.concat(notFundedResults)
+    gsheetRows = gsheetRows.concat(downvotedResults)
+
+    let oceanUSD = curRound.get('OCEAN Price')
+    // 2x Rows => Header & Summed results
+    let burnedFunds = [
+        [
+            'Earmarked USD Burned', '', 'General USD Burned', '', 'Total USD Burned'
+        ],
+        [
+            finalResults.earmarkedResults.fundsLeft,
+            '',
+            finalResults.generalResults.fundsLeft,
+            '',
+            finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft
+        ],
+        [
+            'Earmarked OCEAN Burned', '', 'General OCEAN Burned', '', 'Total OCEAN Burned'
+        ],
+        [
+            finalResults.earmarkedResults.fundsLeft / oceanUSD,
+            '',
+            finalResults.generalResults.fundsLeft / oceanUSD,
+            '',
+            (finalResults.earmarkedResults.fundsLeft + finalResults.generalResults.fundsLeft) / oceanUSD
+        ]
+    ]
+    gsheetRows = gsheetRows.concat(burnedFunds)
+
+    await updateValues(oAuth, sheetName, 'A1:H' + (gsheetRows.length + 1), gsheetRows)
+    console.log('\n[%s]\nDumped [%s] rows to Gsheets', (new Date()).toString(), Object.entries(gsheetRows).length)
 }
 
-main()
+module.exports = {processFundingRoundComplete};

--- a/src/airtable/process_airtable_new_proposals.js
+++ b/src/airtable/process_airtable_new_proposals.js
@@ -1,0 +1,29 @@
+global['fetch'] = require('cross-fetch');
+const dotenv = require('dotenv');
+dotenv.config();
+
+const {getProposalsSelectQuery, updateProposalRecords} = require('./airtable_utils')
+
+// DRY/PARAMETERIZE
+const processAirtableNewProposals = async (curRoundNumber) => {
+    let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
+    let proposalRecords = []
+
+    await Promise.all(inactiveProposals.map(async (p) => {
+        try {
+            proposalRecords.push({
+                id: p['id'],
+                fields: {
+                    'Proposal State': 'Received',
+                    'Round': curRoundNumber
+                }
+            })
+        } catch (err) {
+            console.log(err)
+        }
+    }))
+
+    updateProposalRecords(proposalRecords)
+}
+
+module.exports = {processAirtableNewProposals};

--- a/src/airtable/rounds/funding_rounds.js
+++ b/src/airtable/rounds/funding_rounds.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const {getRoundsSelectQuery} = require('../airtable_utils')
 
 // Let's track the state of various proposals
@@ -23,9 +24,9 @@ const filterCurrentRound = (roundsArr) => {
 }
 
 const getCurrentRound = async () => {
-    const nowDateString = new Date(Date.now()).toISOString().split('T')[0]
+    let nowDateString = moment().utc().toISOString()
     const roundParameters = await getRoundsSelectQuery(`AND({Start Date} <= "${nowDateString}", {Voting Ends} >= "${nowDateString}", "true")`)
-    return filterCurrentRound(roundParameters)
+    return roundParameters[0]
 }
 
 const getWinningProposals = (proposals, curFundingRound) => {

--- a/src/airtable/rounds/funding_rounds.js
+++ b/src/airtable/rounds/funding_rounds.js
@@ -9,6 +9,15 @@ const RoundState = {
     Ended: 'Ended',
 };
 
+const getFundingRound = async (roundNum) => {
+    try {
+        const roundParameters = await getRoundsSelectQuery(`{Round} = "${roundNum}"`)
+        return roundParameters[0]
+    } catch(err) {
+        console.log(err)
+    }
+}
+
 const filterCurrentRound = (roundsArr) => {
     try {
         let timeNow = new Date(Date.now()).getTime()
@@ -118,7 +127,7 @@ const dumpResultsToGSheet = async (results) => {
         try {
             let proposal = res[1]
             let pctYes = proposal.get('Voted Yes') / (proposal.get('Voted Yes') + proposal.get('Voted No'))
-            let greaterThan50Yes = pctYes >= 0.50 ? true : false
+            let greaterThan50Yes = pctYes >= 0.50
             return [
                 proposal.get('Project Name'),
                 proposal.get('Voted Yes'),
@@ -139,4 +148,4 @@ const dumpResultsToGSheet = async (results) => {
     return flatObj
 }
 
-module.exports = {RoundState, getCurrentRound, filterCurrentRound, getWinningProposals, getDownvotedProposals, calculateWinningProposals, calculateFinalResults, dumpResultsToGSheet};
+module.exports = {RoundState, getFundingRound, getCurrentRound, filterCurrentRound, getWinningProposals, getDownvotedProposals, calculateWinningProposals, calculateFinalResults, dumpResultsToGSheet};

--- a/src/airtable/rounds/funding_rounds.js
+++ b/src/airtable/rounds/funding_rounds.js
@@ -1,5 +1,13 @@
 const {getRoundsSelectQuery} = require('../airtable_utils')
 
+// Let's track the state of various proposals
+const RoundState = {
+    Started: 'Started',
+    DueDiligence: 'Due Diligence',
+    Voting: 'Voting',
+    Ended: 'Ended',
+};
+
 const filterCurrentRound = (roundsArr) => {
     try {
         let timeNow = new Date(Date.now()).getTime()
@@ -130,4 +138,4 @@ const dumpResultsToGSheet = async (results) => {
     return flatObj
 }
 
-module.exports = {getCurrentRound, filterCurrentRound, getWinningProposals, getDownvotedProposals, calculateWinningProposals, calculateFinalResults, dumpResultsToGSheet};
+module.exports = {RoundState, getCurrentRound, filterCurrentRound, getWinningProposals, getDownvotedProposals, calculateWinningProposals, calculateFinalResults, dumpResultsToGSheet};

--- a/src/functions/coingecko.js
+++ b/src/functions/coingecko.js
@@ -1,0 +1,22 @@
+const CoinGecko = require('coingecko-api');
+
+const cgClient = new CoinGecko();
+const CG_PARAMS = {
+    market_data: true,
+    tickers: false,
+    community_data: false,
+    developer_data: false,
+    localization: false,
+    sparkline: false,
+}
+
+const getTokenPrice = async () => {
+    try {
+        const result = await cgClient.coins.fetch(process.env.CG_TOKEN_SLUG, CG_PARAMS)
+        return result.data.market_data.current_price['usd']
+    } catch(err) {
+        console.log(err)
+    }
+}
+
+module.exports = {getTokenPrice}

--- a/src/functions/utils.js
+++ b/src/functions/utils.js
@@ -4,4 +4,12 @@ const assert = (condition, message) => {
     }
 }
 
-module.exports = {assert}
+async function sleep(ms) {
+    await _sleep(ms);
+}
+
+function _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+module.exports = {assert, sleep}

--- a/src/gsheets/sync_gsheets_active_proposal_votes_snapshot.js
+++ b/src/gsheets/sync_gsheets_active_proposal_votes_snapshot.js
@@ -6,7 +6,6 @@ const {getProposalsSelectQuery} = require('../airtable/airtable_utils');
 const {initOAuthToken} = require('./gsheets')
 const {getValues, addSheet, updateValues} = require('./gsheets_utils')
 const {getVoteCountStrategy, getProposalVotes} = require('../snapshot/snapshot_utils');
-const {getCurrentRound} = require('../airtable/rounds/funding_rounds')
 
 // DRY/PARAMETERIZE
 var curRoundNumber = undefined
@@ -259,7 +258,7 @@ const getVoterScores = async (provider, strategy, voters, blockHeight) => {
 }
 
 // DRY
-const getActiveProposalVotes = async () => {
+const getActiveProposalVotes = async (curRoundNumber) => {
     activeProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", NOT({Proposal State} = "Rejected"), "true")`)
 
     await Promise.all(activeProposals.map(async (proposal) => {
@@ -303,12 +302,9 @@ const getActiveProposalVotes = async () => {
     }))
 }
 
-const main = async () => {
-    const curRound = await getCurrentRound()
-    curRoundNumber = curRound.get('Round')
-    
+const syncGSheetsActiveProposalVotes = async (curRoundNumber) => {
     // Retrieve all active proposals from Airtable
-    await getActiveProposalVotes()
+    await getActiveProposalVotes(curRoundNumber)
 
     // Output the raw snapshot raw data into gsheets
     Object.entries(proposalVotes).map(async (p) => {
@@ -323,4 +319,4 @@ const main = async () => {
     console.log('Updated GSheets')
 }
 
-main()
+module.exports = {syncGSheetsActiveProposalVotes};

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -5,6 +5,7 @@ dotenv.config();
 const moment = require('moment')
 const {getRoundsSelectQuery, updateRoundRecord} = require('../airtable/airtable_utils')
 const {RoundState, getCurrentRound} = require('../airtable/rounds/funding_rounds')
+const {processAirtableNewProposals} = require('../airtable/process_airtable_new_proposals')
 const {processFundingRoundComplete} = require('../airtable/process_airtable_funding_round_complete')
 const {prepareProposalsForSnapshot} = require('../snapshot/prepare_snapshot_received_proposals_airtable')
 const {submitProposalsToSnapshot} = require('../snapshot/submit_snapshot_accepted_proposals_airtable')
@@ -83,11 +84,13 @@ const main = async () => {
             console.log("Update active round.")
 
             // Preapre proposals for Snapshot (Check token balance, calc snapshot height)
+            processAirtableNewProposals(curRoundNumber)
             prepareProposalsForSnapshot(curRound)
         }else if(curRoundState === RoundState.Started && curRoundProposalsDueBy >= now) {
             console.log("Start DD period.")
 
             // Prepare proposals for Snapshot (Check token balance, calc snapshot height)
+            processAirtableNewProposals(curRoundNumber)
             prepareProposalsForSnapshot(curRound)
 
             // Enter Due Diligence period

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -1,0 +1,109 @@
+global['fetch'] = require('cross-fetch');
+const dotenv = require('dotenv');
+dotenv.config();
+
+const {getRoundsSelectQuery, updateRoundRecord} = require('./airtable_utils')
+const {RoundState, getCurrentRound} = require('./rounds/funding_rounds')
+const {processFundingRoundComplete} = require('../airtable/process_airtable_funding_round_complete')
+const {prepareProposalsForSnapshot} = require('../snapshot/prepare_snapshot_received_proposals_airtable')
+const {submitProposalsToSnapshot} = require('../snapshot/submit_snapshot_accepted_proposals_airtable')
+const {syncAirtableActiveProposalVotes} = require('../airtable/sync_airtable_active_proposal_votes_snapshot')
+const {syncGSheetsActiveProposalVotes} = require('../gsheets/sync_gsheets_active_proposal_votes_snapshot')
+
+const main = async () => {
+    const curRound = await getCurrentRound()
+    const curRoundNumber = curRound.get('Round')
+    const curRoundState = curRound.get('Round State')
+    const curRoundStartDate = curRound.get('Start Date')
+    const curRoundProposalsDueBy = curRound.get('Proposals Due By')
+    const curRoundVoteStart = curRound.get('Voting Starts')
+    const curRoundVoteEnd = curRound.get('Voting End')
+
+    const lastRoundNumber = parseInt(curRoundNumber, 10) - 1
+    let lastRound = await getRoundsSelectQuery(`{Round} = ${lastRoundNumber}`)
+    lastRound = lastRound[0]
+    const lastRoundState = lastRound.get('Round State')
+    const lastRoundVoteEnd = lastRound.get('Voting End')
+
+    const now = new Date().toISOString().split('T')[0]
+
+    if (curRoundState === undefined) {
+        if( lastRoundState === RoundState.Voting && lastRoundVoteEnd <= now) {
+            console.log("Start next round.")
+
+            // Update votes
+            syncAirtableActiveProposalVotes(curRoundNumber)
+            syncGSheetsActiveProposalVotes(curRoundNumber)
+
+            // Complete round calculations
+            processFundingRoundComplete(curRoundNumber)
+
+            // Start the next round
+            const roundUpdate = [{
+                id: lastRound['id'],
+                fields: {
+                    'Round State': RoundState.Ended,
+                }
+            }, {
+                id: curRound['id'],
+                fields: {
+                    'Round State': RoundState.Started,
+                }
+            }]
+            updateRoundRecord(roundUpdate)
+        } else if( curRoundStartDate <= now ) {
+            console.log("Start current round.")
+
+            // Start the current round
+            const roundUpdate = [{
+                id: curRound['id'],
+                fields: {
+                    'Round State': RoundState.Started,
+                }
+            }]
+            updateRoundRecord(roundUpdate)
+        }
+    } else {
+        if(curRoundState === RoundState.Started && curRoundProposalsDueBy < now) {
+            console.log("Update active round.")
+
+            // Preapre proposals for Snapshot (Check token balance, calc snapshot height)
+            prepareProposalsForSnapshot(curRound)
+        }else if(curRoundState === RoundState.Started && curRoundProposalsDueBy >= now) {
+            console.log("Start DD period.")
+
+            // Prepare proposals for Snapshot (Check token balance, calc snapshot height)
+            prepareProposalsForSnapshot(curRound)
+
+            // Enter Due Diligence period
+            const roundUpdate = [{
+                id: curRound['id'],
+                fields: {
+                    'Round State': RoundState.DueDiligence,
+                }
+            }]
+            updateRoundRecord(roundUpdate)
+        }else if(curRoundState === RoundState.DueDiligence && curRoundVoteStart >= now) {
+            console.log("Start Voting period.")
+
+            // Submit to snapshot + Enter voting state
+            submitProposalsToSnapshot(curRoundNumber)
+
+            const roundUpdate = [{
+                id: curRound['id'],
+                fields: {
+                    'Round State': RoundState.Voting,
+                }
+            }]
+            updateRoundRecord(roundUpdate)
+        }else if(curRoundState === RoundState.Voting && curRoundVoteEnd > now) {
+            console.log("Update vote count.")
+
+            // Update votes
+            syncAirtableActiveProposalVotes(curRoundNumber)
+            syncGSheetsActiveProposalVotes(curRoundNumber)
+        }
+    }
+}
+
+main()

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -65,9 +65,9 @@ const prepareProposalsForSnapshot = async (curRound) => {
                     id: proposal.id,
                     fields: {
                         'Proposal State': 'Rejected',
-                        'Voting Starts': undefined,
-                        'Voting Ends': undefined,
-                        'Snapshot Block': undefined,
+                        'Voting Starts': null,
+                        'Voting Ends': null,
+                        'Snapshot Block': null,
                         'Deployment Ready': 'No'
                     }
                 })

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -2,7 +2,6 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const {getProposalsSelectQuery, updateProposalRecords} = require('../airtable/airtable_utils')
-const {getCurrentRound} = require('../airtable/rounds/funding_rounds')
 const {calcTargetBlockHeight} = require('../snapshot/snapshot_utils')
 const {web3} = require('../functions/web3')
 
@@ -28,8 +27,7 @@ const getWalletBalance = async (wallet0x) => {
     return balance
 }
 
-const main = async () => {
-    const curRound = await getCurrentRound()
+const prepareProposalsForSnapshot = async (curRound) => {
     const curRoundNumber = curRound.get('Round')
 
     const voteStartTime = curRound.get('Voting Starts')
@@ -83,4 +81,4 @@ const main = async () => {
     }
 }
 
-main()
+module.exports = {prepareProposalsForSnapshot};

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -47,9 +47,11 @@ const prepareProposalsForSnapshot = async (curRound) => {
     await Promise.all(proposals.map(async (proposal) => {
         try {
             let wallet_0x = proposal.get('Wallet Address')
+            let proposalStanding = proposal.get('Proposal Standing')
+            let goodStanding = proposalStanding === 'Completed' || proposalStanding ==='Refunded'
             let balance = await getWalletBalance(wallet_0x)
 
-            if( balance >= MIN_OCEAN_REQUIRED ) {
+            if( balance >= MIN_OCEAN_REQUIRED && goodStanding === true ) {
                 recordsPayload.push({
                     id: proposal.id,
                     fields: {

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -81,6 +81,8 @@ const prepareProposalsForSnapshot = async (curRound) => {
         await updateProposalRecords(recordsPayload)
         console.log('Updated [%s] records', recordsPayload.length)
     }
+
+    return recordsPayload.length
 }
 
 module.exports = {prepareProposalsForSnapshot};

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -39,7 +39,7 @@ const prepareProposalsForSnapshot = async (curRound) => {
     const startDate = new Date(voteStartTime)
     const voteStartTimestamp = startDate.getTime() / 1000 // get unix timestamp in seconds
 
-    let proposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Received", "true")`)
+    let proposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", OR({Proposal State} = "Received", {Proposal State} = "Rejected"), "true")`)
     let estimatedBlockHeight = calcTargetBlockHeight(currentBlockHeight, voteStartTimestamp, avgBlockTime)
 
     let recordsPayload = []
@@ -53,6 +53,7 @@ const prepareProposalsForSnapshot = async (curRound) => {
                 recordsPayload.push({
                     id: proposal.id,
                     fields: {
+                        'Proposal State': 'Accepted',
                         'Voting Starts': voteStartTime,
                         'Voting Ends': voteEndTime,
                         'Snapshot Block': Number(estimatedBlockHeight),
@@ -63,9 +64,10 @@ const prepareProposalsForSnapshot = async (curRound) => {
                 recordsPayload.push({
                     id: proposal.id,
                     fields: {
-                        'Voting Starts': '',
-                        'Voting Ends': '',
-                        'Snapshot Block': 0,
+                        'Proposal State': 'Rejected',
+                        'Voting Starts': undefined,
+                        'Voting Ends': undefined,
+                        'Snapshot Block': undefined,
                         'Deployment Ready': 'No'
                     }
                 })

--- a/src/snapshot/snapshot_utils.js
+++ b/src/snapshot/snapshot_utils.js
@@ -6,6 +6,15 @@ const fetch = require('cross-fetch')
 const hubUrl = process.env.SNAPSHOT_HUB_URL || 'https://testnet.snapshot.org';
 const space = 'officialoceandao.eth'
 
+const strategy_test = [{
+    name: "erc20-balance-of",
+    params: {
+        symbol: "SPRNG",
+        address: "0x6D40A673446B2D00D1f9E85251209C638049ba22",
+        decimals: 2
+    }
+}]
+
 const strategy_v0_1 = [{
     name: "erc20-balance-of",
     params: {

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -3,7 +3,7 @@ dotenv.config();
 
 const {getProposalsSelectQuery, updateProposalRecords} = require('../airtable/airtable_utils')
 const {buildProposalPayload, local_broadcast_proposal} = require('./snapshot_utils')
-const {assert} = require('../functions/utils')
+const {assert, sleep} = require('../functions/utils')
 const {web3} = require('../functions/web3')
 
 const pk = process.env.ETH_PRIVATE_KEY || 'your_key_here';
@@ -31,12 +31,15 @@ const submitProposalsToSnapshot = async (roundNumber) => {
         acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
 
         // Assert quality
-        await Promise.all(acceptedProposals.map(async (proposal) => {
+        // Foreach may be locking/sync vs. Promise/all which may fire all at once
+        // We probably want to throttle the deployment to snapshot w/ a sleep
+        for(const proposal of acceptedProposals) {
+            // await Promise.all(acceptedProposals.map(async (proposal) => {
             try {
                 validateAccceptedProposal(proposal)
 
-                const payload = buildProposalPayload(proposal)
-                const result = await local_broadcast_proposal(web3, account, payload)
+                const payload = buildProposalPayload(proposal, roundNumber)
+                const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
 
                 if (result !== undefined) {
                     console.log(result)
@@ -44,15 +47,18 @@ const submitProposalsToSnapshot = async (roundNumber) => {
                         id: proposal.id,
                         fields: {
                             'ipfsHash': result.ipfsHash,
-                            'Vote URL': `https://vote.oceanprotocol.com/#/officialoceandao.eth/proposal/${result.ipfsHash}`,
+                            'Vote URL': `https://${process.env.SNAPSHOT_URL}/#/${process.env.SNAPSHOT_SPACE}/proposal/${result.ipfsHash}`,
                             'Proposal State': 'Running'
                         }
                     })
                 }
+
+                await sleep(250)
             } catch (err) {
                 console.log(err)
             }
-        }))
+        // }))
+        }
 
         if (submittedProposals.length > 0) {
             await updateProposalRecords(submittedProposals)

--- a/src/test/airtable/test_airtable_proposals.js
+++ b/src/test/airtable/test_airtable_proposals.js
@@ -1,0 +1,43 @@
+global['fetch'] = require('cross-fetch');
+const dotenv = require('dotenv');
+dotenv.config();
+
+const should = require('chai').should();
+const expect = require('chai').expect;
+const {getProposalsSelectQuery} = require('../../airtable/airtable_utils')
+const {getCurrentRound} = require('../../airtable/rounds/funding_rounds')
+const {processAirtableNewProposals} = require('../../airtable/process_airtable_new_proposals')
+const {prepareProposalsForSnapshot} = require('../../snapshot/prepare_snapshot_received_proposals_airtable')
+
+describe('Testing Proposals', function() {
+    it.skip('Validates proposals that are not been initialized.', async function() {
+        let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
+        should.equal(inactiveProposals.length, 1);
+    });
+
+    it.skip('Initializes proposals for this round.', async function() {
+        let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
+
+        if( inactiveProposals.length > 0 ) {
+            const currentRound = await getCurrentRound()
+            if( currentRound !== undefined ) {
+                const curRoundNumber = currentRound.get('Round')
+                await processAirtableNewProposals(curRoundNumber)
+
+                inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
+                should.equal(inactiveProposals.length, 0);
+            }
+        }
+    });
+
+    it('Processes proposals for snapshot.', async function() {
+        const currentRound = await getCurrentRound()
+        if( currentRound !== undefined ) {
+            await prepareProposalsForSnapshot(currentRound)
+
+            const curRoundNumber = currentRound.get('Round')
+            let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Accepted", "true")`)
+            expect(acceptedProposals.length).to.be.greaterThan(0);
+        }
+    }).timeout(5000);
+});

--- a/src/test/airtable/test_airtable_round_winners.js
+++ b/src/test/airtable/test_airtable_round_winners.js
@@ -3,7 +3,6 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const should = require('chai').should();
-const expect = require('chai').expect;
 const {getWinningProposals, getDownvotedProposals, calculateWinningProposals, calculateFinalResults, dumpResultsToGSheet} = require('../../airtable/rounds/funding_rounds')
 
 var fundingRound = {}

--- a/src/test/scripts/test_update_funding_round.js
+++ b/src/test/scripts/test_update_funding_round.js
@@ -9,10 +9,18 @@ const {getCurrentRound} = require('../../airtable/rounds/funding_rounds')
 const {processAirtableNewProposals} = require('../../airtable/process_airtable_new_proposals')
 const {prepareProposalsForSnapshot} = require('../../snapshot/prepare_snapshot_received_proposals_airtable')
 
-describe('Testing Proposals', function() {
+async function sleep(ms) {
+    await _sleep(ms);
+}
+
+function _sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('Testing updateFundingRound', function() {
     it.skip('Validates proposals that are not been initialized.', async function() {
         let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
-        should.equal(inactiveProposals.length, 1);
+        expect(inactiveProposals.length).to.be.greaterThan(0);
     });
 
     it.skip('Initializes proposals for this round.', async function() {
@@ -24,11 +32,12 @@ describe('Testing Proposals', function() {
                 const curRoundNumber = currentRound.get('Round')
                 await processAirtableNewProposals(curRoundNumber)
 
+                await sleep(500)
                 inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
                 should.equal(inactiveProposals.length, 0);
             }
         }
-    });
+    }).timeout(5000);
 
     it('Processes proposals for snapshot.', async function() {
         const currentRound = await getCurrentRound()

--- a/src/test/scripts/test_update_funding_round.js
+++ b/src/test/scripts/test_update_funding_round.js
@@ -12,7 +12,9 @@ const {submitProposalsToSnapshot} = require('../../snapshot/submit_snapshot_acce
 const {sleep} = require('../../functions/utils')
 
 // To run these tests, you should setup the DB beforehand
-// Requirement: 1 proposal in DB w/o "Round" or "Proposal State" params
+// Requirement:
+// - 1 funding round where the "Start Date" < now < "Voting Ends"
+// - 1 proposal in DB w/o "Round" or "Proposal State" params
 // 1. In DB - Delete a proposal "Round" + "Propoal State" params.
 describe('Functionally test updateFundingRound', function() {
     it.skip('Validates proposals that are not been initialized.', async function() {
@@ -20,7 +22,7 @@ describe('Functionally test updateFundingRound', function() {
         expect(inactiveProposals.length).to.be.greaterThan(0);
     });
 
-    it('Initializes proposals for this round.', async function() {
+    it.skip('Initializes proposals for this round.', async function() {
         let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
 
         if( inactiveProposals.length > 0 ) {
@@ -36,7 +38,7 @@ describe('Functionally test updateFundingRound', function() {
         }
     }).timeout(5000);
 
-    it('Processes proposals for snapshot.', async function() {
+    it.skip('Processes proposals for snapshot.', async function() {
         const currentRound = await getCurrentRound()
         if( currentRound !== undefined ) {
             await prepareProposalsForSnapshot(currentRound)
@@ -48,7 +50,7 @@ describe('Functionally test updateFundingRound', function() {
         }
     }).timeout(5000);
 
-    it('Deploys proposals to snapshot.', async function() {
+    it.skip('Deploys proposals to snapshot.', async function() {
         const currentRound = await getCurrentRound()
         if( currentRound !== undefined ) {
             // Submit to snapshot + Enter voting state

--- a/src/test/scripts/test_update_funding_round.js
+++ b/src/test/scripts/test_update_funding_round.js
@@ -8,22 +8,19 @@ const {getProposalsSelectQuery} = require('../../airtable/airtable_utils')
 const {getCurrentRound} = require('../../airtable/rounds/funding_rounds')
 const {processAirtableNewProposals} = require('../../airtable/process_airtable_new_proposals')
 const {prepareProposalsForSnapshot} = require('../../snapshot/prepare_snapshot_received_proposals_airtable')
+const {submitProposalsToSnapshot} = require('../../snapshot/submit_snapshot_accepted_proposals_airtable')
+const {sleep} = require('../../functions/utils')
 
-async function sleep(ms) {
-    await _sleep(ms);
-}
-
-function _sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-describe('Testing updateFundingRound', function() {
+// To run these tests, you should setup the DB beforehand
+// Requirement: 1 proposal in DB w/o "Round" or "Proposal State" params
+// 1. In DB - Delete a proposal "Round" + "Propoal State" params.
+describe('Functionally test updateFundingRound', function() {
     it.skip('Validates proposals that are not been initialized.', async function() {
         let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
         expect(inactiveProposals.length).to.be.greaterThan(0);
     });
 
-    it.skip('Initializes proposals for this round.', async function() {
+    it('Initializes proposals for this round.', async function() {
         let inactiveProposals = await getProposalsSelectQuery(`AND({Round} = "", {Proposal State} = "", "true")`)
 
         if( inactiveProposals.length > 0 ) {
@@ -44,9 +41,23 @@ describe('Testing updateFundingRound', function() {
         if( currentRound !== undefined ) {
             await prepareProposalsForSnapshot(currentRound)
 
+            await sleep(500)
             const curRoundNumber = currentRound.get('Round')
             let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Accepted", "true")`)
             expect(acceptedProposals.length).to.be.greaterThan(0);
         }
     }).timeout(5000);
+
+    it('Deploys proposals to snapshot.', async function() {
+        const currentRound = await getCurrentRound()
+        if( currentRound !== undefined ) {
+            // Submit to snapshot + Enter voting state
+            const curRoundNumber = currentRound.get('Round')
+            await submitProposalsToSnapshot(curRoundNumber)
+
+            await sleep(500)
+            let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
+            expect(acceptedProposals.length).to.be.greaterThan(0);
+        }
+    }).timeout(90000);
 });

--- a/src/test/test_get_token_price.js
+++ b/src/test/test_get_token_price.js
@@ -1,0 +1,14 @@
+const {getTokenPrice} = require('../../src/functions/coingecko')
+const dotenv = require('dotenv');
+dotenv.config();
+
+const expect = require('chai').expect;
+
+describe('Calculating Winners', function() {
+    it('Should validate token price > 0.0', async function () {
+        const tokenPrice = await getTokenPrice()
+        console.log('CoinGecko: Token Price', tokenPrice)
+
+        expect(tokenPrice).to.be.greaterThan(0.0);
+    });
+})

--- a/src/test/test_submit_proposal.js
+++ b/src/test/test_submit_proposal.js
@@ -1,3 +1,6 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
 const {local_broadcast_proposal} = require('../snapshot/snapshot_utils')
 const {web3} = require('../functions/web3')
 
@@ -5,37 +8,38 @@ const pk = process.env.ETH_PRIVATE_KEY || 'your_key_here';
 const account = web3.eth.accounts.privateKeyToAccount(pk)
 web3.eth.accounts.wallet.add(account);
 web3.eth.defaultAccount = account.address;
-const snapshot_url = 'https://testnet.snapshot.org'
+const snapshot_url = process.env.SNAPSHOT_HUB_URL
 
 const payload = {
-    "name": "Initial Alex Offering",
-    "body": "Read more about the proposal here:\nhttps://medium.com/@AlexMasmej/taking-risks-during-chaos-initial-alex-offering-339883bb7f6d\n\nOne Liner\nAlex is revolutionizing self-actualization.\n\nGrant Deliverables:\nThis grant supports the following deliverables:\n1. Alex creating an awesome coin\n    - [The Case for Alex Coin](https://www.coingecko.com/en/coins/alex)\n2. Another case for Alex Coin\n    - [Next case for Alex Coin](https://www.coingecko.com/en/coins/alex)\n3. [The actual case for Alex Coin](https://www.coingecko.com/en/coins/alex)\n4. Therefore, investing in Alex Coin is investing in the future.\n\n\nEngage in community conversation, questions and feedback:\n\n###Dates:\nVoting opens on Sun, 02 May 2021 00:00:00 GMT GMT.\nVoting closes on Sun, 02 May 2021 00:00:00 GMT GMT.\n\n###Cast your vote below!",
+    "name": "Spring Proposal",
+    "body": "Vote below",
     "choices": [
         "Yes",
         "No"
     ],
     "type": "single-choice",
-    "start": 1622676600,
-    "end": 1622677500,
-    "snapshot": 12557832,
+    "start": 1630471000,
+    "end": 1630475000,
+    "snapshot": 13135768,
     "metadata": {
         "strategies": [
             {
                 "network": 1,
                 "name": "erc20-balance-of",
                 "params": {
-                    "symbol": "ALEX",
-                    "address": "0x8BA6DcC667d3FF64C1A2123cE72FF5F0199E5315",
-                    "decimals": 4
+                    "symbol": "SPRNG",
+                    "address": "0x6D40A673446B2D00D1f9E85251209C638049ba22",
+                    "decimals": 2
                 }
             }
         ]
     }
 }
 
+// TODO - Build payload programmatically
 const testPayload = async () => {
     try {
-        const result = await local_broadcast_proposal(web3, account, payload, pSpace='alex', pUrl=snapshot_url)
+        const result = await local_broadcast_proposal(web3, account, payload, pSpace='spring-dao', pUrl=snapshot_url)
         console.log("Results are: ", result)
     } catch(err) {
         console.log(err)


### PR DESCRIPTION
Changes proposed in this PR:
- Restructured all DAOBot exec scripts into functions
- DAOBot now has 1 main entry point: update_funding_round.js
- Did a pass on time-related functionality so that everything is based on GMT
- Added a [Funding Round State] so that it's easier to process the funding round
- Added functionality so new proposals that are not properly configured (no [state|round]) are automatically initiatlized.
- Added tests to validate round execution.
- Updated Snapshot deployment so proposals are throttled, eliminating deployment errors
- Updated various .env configurations so that DAOBot is more easily configured
- Updated test_submit_proposal to use `spring-dao` space instead of `alexj`