### PR TITLE
Update DAOBot to implement QV & Weighted voting.

### DIFF
--- a/src/airtable/airtable_utils.js
+++ b/src/airtable/airtable_utils.js
@@ -37,10 +37,11 @@ const sumSnapshotVotesToAirtable = async (proposals, scores) => {
     let records = []
     proposals.map((p) => {
         const batchIndex = p.get('Snapshot Batch Index')
+        const batchNoIndex = p.get('Snapshot Batch Index No')
         const ipfsHash = p.get('ipfsHash')
 
         const yesIndex = batchIndex === undefined ? 1 : batchIndex
-        const noIndex = batchIndex === undefined ? 2 : undefined
+        const noIndex = batchNoIndex === undefined ? 2 : batchNoIndex
 
         const yesVotes = scores[ipfsHash][yesIndex] === undefined ? 0 : scores[ipfsHash][yesIndex]
         const noVotes = scores[ipfsHash][noIndex] === undefined ? 0 : scores[ipfsHash][noIndex]

--- a/src/gsheets/sync_gsheets_active_proposal_votes_snapshot.js
+++ b/src/gsheets/sync_gsheets_active_proposal_votes_snapshot.js
@@ -57,10 +57,11 @@ const calculateProposalSummary = async (proposals, voterScores, proposalScores) 
     proposals.map((p) => {
         // TODO - Add support for non-granular voting system
         const batchIndex = p.get('Snapshot Batch Index')
+        const batchIndexNo = p.get('Snapshot Batch Index No')
         const ipfsHash = p.get('ipfsHash')
 
         const yesIndex = batchIndex === undefined ? 1 : batchIndex
-        const noIndex = batchIndex === undefined ? 2 : undefined
+        const noIndex = batchIndexNo === undefined ? 2 : batchIndexNo
 
         const yesVotes = proposalScores[ipfsHash][yesIndex] || 0
         const noVotes = noIndex === 2 ? proposalScores[ipfsHash][noIndex] : 0
@@ -92,6 +93,8 @@ const calculateProposalSummary = async (proposals, voterScores, proposalScores) 
 const calculateRoundSummary = async (proposals, voterScores, proposalScores) => {
     // push all votes, from all proposals into a single object
     let votes = []
+
+    // TODO - Update function to support Y/N voting
     const batchMode = proposals[0].get('Snapshot Batch Index') !== undefined
     // If Granular Voting
     if(batchMode === true) {
@@ -138,7 +141,7 @@ const calculateRoundSummary = async (proposals, voterScores, proposalScores) => 
                 walletSummary[address]['sumNo'] = 0
             })
         } else {
-            Object.values(w).map((v) => {
+            Object.values(w).map((v) => {proposalScores
                 walletSummary[address]['numVotes']++;
                 walletSummary[address]['numYes'] += v[1] === 1 ? 1 : 0
                 walletSummary[address]['numNo'] += v[1] === 2 ? 1 : 0

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -211,7 +211,7 @@ const main = async () => {
 
             // Update votes
             await syncAirtableActiveProposalVotes(curRoundNumber)
-            await syncGSheetsActiveProposalVotes(curRoundNumber)
+            await syncGSheetsActiveProposalVotes(curRoundBallotType, curRoundNumber)
         }
     }
 }

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -8,7 +8,7 @@ const {RoundState, getCurrentRound} = require('../airtable/rounds/funding_rounds
 const {processAirtableNewProposals} = require('../airtable/process_airtable_new_proposals')
 const {processFundingRoundComplete} = require('../airtable/process_airtable_funding_round_complete')
 const {prepareProposalsForSnapshot} = require('../snapshot/prepare_snapshot_received_proposals_airtable')
-const {submitProposalsToSnapshot} = require('../snapshot/submit_snapshot_accepted_proposals_airtable')
+const {submitProposalsToSnaphotBatch} = require('../snapshot/submit_snapshot_accepted_proposals_airtable')
 const {syncAirtableActiveProposalVotes} = require('../airtable/sync_airtable_active_proposal_votes_snapshot')
 const {syncGSheetsActiveProposalVotes} = require('../gsheets/sync_gsheets_active_proposal_votes_snapshot')
 const {sleep} = require('../functions/utils')
@@ -134,7 +134,7 @@ const main = async () => {
             console.log("Start Voting period.")
 
             // Submit to snapshot + Enter voting state
-            await submitProposalsToSnapshot(curRoundNumber)
+            await submitProposalsToSnaphotBatch(curRoundNumber)
 
             const roundUpdate = [{
                 id: curRound['id'],

--- a/src/snapshot/snapshot_utils.js
+++ b/src/snapshot/snapshot_utils.js
@@ -203,16 +203,22 @@ const reduceVoterScores = (strategy, proposalVotes, voterScores) => {
 
 // Returns reduced proposal summary based on many voters => {1:int,2:int}
 const reduceProposalScores = (voterScores) => {
-    let scores = {
-        1: 0,
-        2: 0
-    }
-
+    let scores = {}
+    
     Object.entries(voterScores).reduce((total, cur) => {
-        const choice = cur[1].choice
-        const balance = cur[1].balance
-        if (scores[choice] === undefined) scores[choice] = 0
-        scores[choice] += balance
+        const voterAllChoices = cur[1].choice
+        const voterTotalBalance = cur[1].balance
+
+        let voterVotesCount = 0
+        for (const [_, vote] of Object.entries(voterAllChoices)) {
+            voterVotesCount += vote
+        }
+        
+        for (const [proposalIndex, proposalVotes] of Object.entries(voterAllChoices)) {
+            if (scores[proposalIndex] === undefined) scores[proposalIndex] = 0
+            scores[proposalIndex] += (voterVotesCount > 0 && voterTotalBalance > 0 && proposalVotes > 0) ?
+            ((voterTotalBalance / voterVotesCount) * proposalVotes) : 0
+        }
     }, {})
 
     return scores

--- a/src/snapshot/snapshot_utils.js
+++ b/src/snapshot/snapshot_utils.js
@@ -277,7 +277,7 @@ ${x.get('Project Name')} - [Click Here](${x.get('Proposal URL')})
     return payload = {
         end: endTs,
         body: body,
-        name: `Test Proposal ${roundNumber}`,
+        name: `OceanDAO Round${roundNumber}`,
         type: voteType,
         start: startTs,
         choices: choices,

--- a/src/snapshot/snapshot_utils.js
+++ b/src/snapshot/snapshot_utils.js
@@ -118,7 +118,13 @@ const strategy = {
 
 const VoteType = {
     SingleChoice: "single-choice",
-    Quadratic: "quadratic"
+    Quadratic: "quadratic",
+    Weighted: "weighted",
+}
+
+const BallotType = {
+    Batch: "Batch",
+    Granular: "Granular"
 }
 
 const getVoteCountStrategy = (roundNumber) => {
@@ -271,7 +277,7 @@ ${x.get('Project Name')} - [Click Here](${x.get('Proposal URL')})
     return payload = {
         end: endTs,
         body: body,
-        name: `OceanDAO Round ${roundNumber}`,
+        name: `Test Proposal ${roundNumber}`,
         type: voteType,
         start: startTs,
         choices: choices,
@@ -351,5 +357,6 @@ module.exports = {
     buildBatchProposalPayload,
     local_broadcast_proposal,
     calcTargetBlockHeight,
-    VoteType
+    VoteType,
+    BallotType
 }

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -2,7 +2,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const {getProposalsSelectQuery, updateProposalRecords} = require('../airtable/airtable_utils')
-const {buildGranularProposalPayload, buildBatchProposalPayload, local_broadcast_proposal, VoteType} = require('./snapshot_utils')
+const {buildGranularProposalPayload, buildBatchProposalPayload, local_broadcast_proposal, VoteType, BallotType} = require('./snapshot_utils')
 const {assert, sleep} = require('../functions/utils')
 const {web3} = require('../functions/web3')
 
@@ -22,7 +22,7 @@ const validateAccceptedProposal = (proposal) => {
 
 // All required fields should have already been validated by the online Form
 // Build payload for proposal, and submit it
-const submitProposalsToSnaphotGranular = async (roundNumber) => {
+const submitProposalsToSnaphotGranular = async (roundNumber, voteType) => {
     try {
         // TODO - Parameterize (Docker) + CI/CD Deploy Button + PEBKAC
         const acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
@@ -35,7 +35,7 @@ const submitProposalsToSnaphotGranular = async (roundNumber) => {
             try {
                 validateAccceptedProposal(proposal)
 
-                const payload = buildGranularProposalPayload(proposal, roundNumber, VoteType.SingleChoice)
+                const payload = buildGranularProposalPayload(proposal, roundNumber, voteType)
                 const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
 
                 if (result !== undefined) {
@@ -67,7 +67,7 @@ const submitProposalsToSnaphotGranular = async (roundNumber) => {
     }
 }
 
-const submitProposalsToSnaphotBatch = async (roundNumber) => {
+const submitProposalsToSnaphotBatch = async (roundNumber, voteType) => {
     try {
         // TODO - Parameterize (Docker) + CI/CD Deploy Button + PEBKAC
         const acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
@@ -87,7 +87,7 @@ const submitProposalsToSnaphotBatch = async (roundNumber) => {
             console.log(err)
         }
 
-        const payload = buildBatchProposalPayload(acceptedProposals, proposalArr, roundNumber, VoteType.Quadratic)
+        const payload = buildBatchProposalPayload(acceptedProposals, proposalArr, roundNumber, voteType)
         const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
         console.log(result)
 

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -2,7 +2,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const {getProposalsSelectQuery, updateProposalRecords} = require('../airtable/airtable_utils')
-const {buildProposalPayload, local_broadcast_proposal} = require('./snapshot_utils')
+const {buildGranularProposalPayload, buildBatchProposalPayload, local_broadcast_proposal, VoteType} = require('./snapshot_utils')
 const {assert, sleep} = require('../functions/utils')
 const {web3} = require('../functions/web3')
 
@@ -10,9 +10,6 @@ const pk = process.env.ETH_PRIVATE_KEY || 'your_key_here';
 const account = web3.eth.accounts.privateKeyToAccount(pk)
 web3.eth.accounts.wallet.add(account);
 web3.eth.defaultAccount = account.address;
-
-var acceptedProposals = {}
-var submittedProposals = []
 
 const validateAccceptedProposal = (proposal) => {
     assert(proposal.get('One Liner') !== undefined, '[%s][%s]: Invalid <One Liner>', proposal.id, proposal.get('Name'))
@@ -25,20 +22,20 @@ const validateAccceptedProposal = (proposal) => {
 
 // All required fields should have already been validated by the online Form
 // Build payload for proposal, and submit it
-const submitProposalsToSnapshot = async (roundNumber) => {
+const submitProposalsToSnaphotGranular = async (roundNumber) => {
     try {
         // TODO - Parameterize (Docker) + CI/CD Deploy Button + PEBKAC
-        acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
+        const acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
 
         // Assert quality
         // Foreach may be locking/sync vs. Promise/all which may fire all at once
         // We probably want to throttle the deployment to snapshot w/ a sleep
+        let submittedProposals = []
         for(const proposal of acceptedProposals) {
-            // await Promise.all(acceptedProposals.map(async (proposal) => {
             try {
                 validateAccceptedProposal(proposal)
 
-                const payload = buildProposalPayload(proposal, roundNumber)
+                const payload = buildGranularProposalPayload(proposal, roundNumber, VoteType.SingleChoice)
                 const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
 
                 if (result !== undefined) {
@@ -57,7 +54,6 @@ const submitProposalsToSnapshot = async (roundNumber) => {
             } catch (err) {
                 console.log(err)
             }
-        // }))
         }
 
         if (submittedProposals.length > 0) {
@@ -71,4 +67,60 @@ const submitProposalsToSnapshot = async (roundNumber) => {
     }
 }
 
-module.exports = {submitProposalsToSnapshot};
+const submitProposalsToSnaphotBatch = async (roundNumber) => {
+    try {
+        // TODO - Parameterize (Docker) + CI/CD Deploy Button + PEBKAC
+        const acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${roundNumber}", {Proposal State} = "Accepted", "true")`)
+
+        let proposalIndex = {} // let's keep a dict of proposalName + y/n indexes
+        let proposalArr = [] // let's keep all proposals Y/N in an ordered array
+        let index = 1
+        try {
+            for(const proposal of acceptedProposals) {
+                validateAccceptedProposal(proposal)
+                proposalIndex[proposal.get('Project Name')] = [index, index + 1]
+                proposalArr.push(proposal.get('Project Name') + '_Yes' )
+                proposalArr.push(proposal.get('Project Name') + '_No' )
+                index += 2
+            }
+        } catch (err) {
+            console.log(err)
+        }
+
+        const payload = buildBatchProposalPayload(acceptedProposals, proposalArr, roundNumber, VoteType.Quadratic)
+        const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
+        console.log(result)
+
+        let submittedProposals = []
+        if (result !== undefined) {
+            for(const proposal of acceptedProposals) {
+                try {
+                    const index = proposalIndex[proposal.get('Project Name')]
+                    submittedProposals.push({
+                        id: proposal.id,
+                        fields: {
+                            'ipfsHash': result.ipfsHash,
+                            'Vote URL': `https://${process.env.SNAPSHOT_URL}/#/${process.env.SNAPSHOT_SPACE}/proposal/${result.ipfsHash}`,
+                            'Proposal State': 'Running',
+                            'Snapshot Batch Index': index[0],
+                            'Snapshot Batch Index No': index[1],
+                        }
+                    })
+                } catch (err) {
+                    console.log(err)
+                }
+            }
+        }
+
+        if (submittedProposals.length > 0) {
+            await updateProposalRecords(submittedProposals)
+            console.log('[SUCCESS] Submitted [%s] proposals to Snapshot.', submittedProposals.length)
+        }
+        if (acceptedProposals.length !== submittedProposals.length)
+            console.log('[WARNING] Accepted [%s] proposals, but only submitted [%s]. Please check logs.', acceptedProposals.length, submittedProposals.length)
+    } catch(err) {
+        console.log(err)
+    }
+}
+
+module.exports = {submitProposalsToSnaphotGranular, submitProposalsToSnaphotBatch};

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -32,28 +32,24 @@ const submitProposalsToSnaphotGranular = async (roundNumber, voteType) => {
         // We probably want to throttle the deployment to snapshot w/ a sleep
         let submittedProposals = []
         for(const proposal of acceptedProposals) {
-            try {
-                validateAccceptedProposal(proposal)
+            validateAccceptedProposal(proposal)
 
-                const payload = buildGranularProposalPayload(proposal, roundNumber, voteType)
-                const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
+            const payload = buildGranularProposalPayload(proposal, roundNumber, voteType)
+            const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
 
-                if (result !== undefined) {
-                    console.log(result)
-                    submittedProposals.push({
-                        id: proposal.id,
-                        fields: {
-                            'ipfsHash': result.ipfsHash,
-                            'Vote URL': `https://${process.env.SNAPSHOT_URL}/#/${process.env.SNAPSHOT_SPACE}/proposal/${result.ipfsHash}`,
-                            'Proposal State': 'Running'
-                        }
-                    })
-                }
-
-                await sleep(250)
-            } catch (err) {
-                console.log(err)
+            if (result !== undefined) {
+                console.log(result)
+                submittedProposals.push({
+                    id: proposal.id,
+                    fields: {
+                        'ipfsHash': result.ipfsHash,
+                        'Vote URL': `https://${process.env.SNAPSHOT_URL}/#/${process.env.SNAPSHOT_SPACE}/proposal/${result.ipfsHash}`,
+                        'Proposal State': 'Running'
+                    }
+                })
             }
+
+            await sleep(250)
         }
 
         if (submittedProposals.length > 0) {
@@ -75,18 +71,15 @@ const submitProposalsToSnaphotBatch = async (roundNumber, voteType) => {
         let proposalIndex = {} // let's keep a dict of proposalName + y/n indexes
         let proposalArr = [] // let's keep all proposals Y/N in an ordered array
         let index = 1
-        try {
-            for(const proposal of acceptedProposals) {
-                validateAccceptedProposal(proposal)
-                proposalIndex[proposal.get('Project Name')] = [index, index + 1]
-                proposalArr.push(proposal.get('Project Name') + '_Yes' )
-                proposalArr.push(proposal.get('Project Name') + '_No' )
-                index += 2
-            }
-        } catch (err) {
-            console.log(err)
-        }
 
+        for(const proposal of acceptedProposals) {
+            validateAccceptedProposal(proposal)
+            proposalIndex[proposal.get('Project Name')] = [index, index + 1]
+            proposalArr.push(proposal.get('Project Name') + '_Yes' )
+            proposalArr.push(proposal.get('Project Name') + '_No' )
+            index += 2
+        }
+        
         const payload = buildBatchProposalPayload(acceptedProposals, proposalArr, roundNumber, voteType)
         const result = await local_broadcast_proposal(web3, account, payload, process.env.SNAPSHOT_SPACE)
         console.log(result)

--- a/src/test/scripts/test_update_funding_round.js
+++ b/src/test/scripts/test_update_funding_round.js
@@ -10,7 +10,7 @@ const {getRoundsSelectQuery, getProposalsSelectQuery} = require('../../airtable/
 const {getCurrentRound} = require('../../airtable/rounds/funding_rounds')
 const {processAirtableNewProposals} = require('../../airtable/process_airtable_new_proposals')
 const {prepareProposalsForSnapshot} = require('../../snapshot/prepare_snapshot_received_proposals_airtable')
-const {submitProposalsToSnapshot} = require('../../snapshot/submit_snapshot_accepted_proposals_airtable')
+const {submitProposalsToSnaphotGranular, submitProposalsToSnaphotBatch} = require('../../snapshot/submit_snapshot_accepted_proposals_airtable')
 const {sleep} = require('../../functions/utils')
 
 // To run these tests, you should setup the DB beforehand
@@ -49,7 +49,7 @@ describe('Functionally test updateFundingRound', function() {
         }
     }).timeout(5000);
 
-    it.skip('Processes proposals for snapshot.', async function() {
+    it('Processes proposals for snapshot.', async function() {
         const currentRound = await getCurrentRound()
         if( currentRound !== undefined ) {
             await prepareProposalsForSnapshot(currentRound)
@@ -59,18 +59,31 @@ describe('Functionally test updateFundingRound', function() {
             let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Accepted", "true")`)
             expect(acceptedProposals.length).to.be.greaterThan(0);
         }
-    }).timeout(5000);
+    }).timeout(10000);
 
-    it.skip('Deploys proposals to snapshot.', async function() {
+    it.skip('Deploys proposals to snapshot into multiple ballots.', async function() {
         const currentRound = await getCurrentRound()
         if( currentRound !== undefined ) {
             // Submit to snapshot + Enter voting state
             const curRoundNumber = currentRound.get('Round')
-            await submitProposalsToSnapshot(curRoundNumber)
+            await submitProposalsToSnaphotGranular(curRoundNumber)
 
             await sleep(500)
             let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
             expect(acceptedProposals.length).to.be.greaterThan(0);
         }
     }).timeout(90000);
+
+    it('Deploys proposals to snapshot in a single ballot.', async function() {
+        const currentRound = await getCurrentRound()
+        if( currentRound !== undefined ) {
+            // Submit to snapshot + Enter voting state
+            const curRoundNumber = currentRound.get('Round')
+            await submitProposalsToSnaphotBatch(curRoundNumber)
+
+            await sleep(500)
+            let acceptedProposals = await getProposalsSelectQuery(`AND({Round} = "${curRoundNumber}", {Proposal State} = "Running", "true")`)
+            expect(acceptedProposals.length).to.be.greaterThan(0);
+        }
+    }).timeout(10000);
 });


### PR DESCRIPTION
As defined inside of [this ticket](https://github.com/oceanprotocol/oceandao/issues/16).

This PR includes all code required to configure:
`Vote Type`: single-choice, quadratic, weighted
`Ballot Type`: Batch (N Proposals -> 1 Ballot) or Granular (N Proposals -> N Ballots)

This makes it so that:
- DAOBot can be easily configured per-round.
- Round configurations are easily understood via Airtable views.

This PR include: 
- [x] Code required to update Airtable
- [x] Code required to update GSheets

I have updated the [Funding Rounds] table inside of Airtable Prod to include the configuration as found inside of my [Dev Airtable environment](https://airtable.com/shruIHermw4LiMs2x), in preparation for the merge of this PR.