### PR TITLE
Fix update proposals is changing "Funded" proposals into "Rejected"

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -261,7 +261,7 @@ const processHistoricalStandings = async (proposalStandings) => {
 const getProjectStandingStatus = (proposalStandings) => {
   for (const proposal of proposalStandings) {
     if (
-      proposal.fields['Proposal State'] === State.Funded &&
+      isFunded(proposal.fields['Proposal State']) &&
       (proposal.fields['Proposal Standing'] === Standings.Unreported ||
         proposal.fields['Proposal Standing'] === Standings.Incomplete ||
         proposal.fields['Proposal Standing'] === Standings.Dispute)

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -261,9 +261,10 @@ const processHistoricalStandings = async (proposalStandings) => {
 const getProjectStandingStatus = (proposalStandings) => {
   for (const proposal of proposalStandings) {
     if (
-      proposal.fields['Proposal Standing'] === Standings.Unreported ||
-      proposal.fields['Proposal Standing'] === Standings.Incomplete ||
-      proposal.fields['Proposal Standing'] === Standings.Dispute
+      proposal.fields['Proposal State'] === State.Funded &&
+      (proposal.fields['Proposal Standing'] === Standings.Unreported ||
+        proposal.fields['Proposal Standing'] === Standings.Incomplete ||
+        proposal.fields['Proposal Standing'] === Standings.Dispute)
     ) {
       return ProjectStandingsStatus.Bad
     }

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -169,7 +169,7 @@ beforeEach(async function () {
         'Project Name': 'test',
         'Proposal URL': 'www.testurl.com',
         'Proposal State': State.Funded,
-        'Proposal Standing': undefined,
+        'Proposal Standing': Standings.Unreported,
         'Deliverable Checklist': '[x] D1\n[x] D2\n[x] D3',
         'Last Deliverable Update': 'Apr 01, 2021',
         'Refund Transaction': undefined,
@@ -254,6 +254,13 @@ describe('Process Project Standings', function () {
         Standings.NoOcean
       ])
     })
+
+    // expect last elements Proposal Standing to be `Standings.Completed`
+    expect(
+      proposalStandings[projectName].find((x) => x.id == 'proposal_6').fields[
+        'Proposal Standing'
+      ]
+    ).to.equal(Standings.Completed)
   })
 
   it('If proposalStanding is Incomplete then remainder of projectStanding is Incomplete', async function () {

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -257,7 +257,7 @@ describe('Process Project Standings', function () {
 
     // expect last elements Proposal Standing to be `Standings.Completed`
     expect(
-      proposalStandings[projectName].find((x) => x.id == 'proposal_6').fields[
+      proposalStandings[projectName].find((x) => x.id === 'proposal_6').fields[
         'Proposal Standing'
       ]
     ).to.equal(Standings.Completed)


### PR DESCRIPTION
Fixes #68.

Changes proposed in this PR:

If the proposal is not funded, we don't need to check if it has a bad standing status.
`getProjectStandingStatus` function will return `ProjectStandingsStatus.Good` if the `Proposal State` **is not** `Funded`.