### PR TITLE
Call `dotenv.config()` before declaring `logger`

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,11 +1,11 @@
 const dotenv = require('dotenv')
+dotenv.config()
 const logger = require('pino')({
   level: process.env.LOG_LEVEL || 'info',
   transport: {
     target: 'pino-pretty'
   }
 })
-dotenv.config()
 const _get = (type, ...args) => {
   switch (type) {
     case 'log':


### PR DESCRIPTION
Fixes #71 .

Changes proposed in this PR:

- Call `dotenv.config()` before declaring `logger`
- 
- 