### PR TITLE
Fix DAObot bugs

### DIFF
--- a/src/airtable/process_airtable_all_proposal_standings.js
+++ b/src/airtable/process_airtable_all_proposal_standings.js
@@ -59,6 +59,7 @@ const processAirtableProposalStandings = async (curRoundNumber) => {
   // drop all extra columns
   rows.forEach((x) => {
     if (x.fields['Proposal URL']) delete x.fields['Proposal URL']
+    if (x.fields['Bad Status']) delete x.fields['Bad Status']
   })
 
   // Finally, update all DB records

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -315,7 +315,8 @@ const updateCurrentRoundStandings = (
     const latestProposal = latestProposals[key]
     if (latestProposal !== undefined) {
       if (latestProposal.fields['Bad Status'] === true) {
-        value[0].fields['Proposal Standing'] = Standings.Unreported
+        value[0].fields['Proposal Standing'] =
+          latestProposal.fields['Proposal Standing']
         value[0].fields['Proposal State'] = State.Rejected
         value[0].fields['Outstanding Proposals'] =
           latestProposal.fields['Outstanding Proposals']

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -73,9 +73,16 @@ const getProjectStanding = (
 }
 
 const getProposalState = (proposalState, hasEnoughOceans) => {
-  if (hasEnoughOceans && proposalState === State.Rejected) {
+  // TODO find a better logic for this
+  if (
+    hasEnoughOceans &&
+    (proposalState === State.Rejected || proposalState === State.Undefined)
+  ) {
     proposalState = State.Accepted
+  } else if (proposalState === State.Undefined) {
+    proposalState = State.Rejected
   }
+
   return proposalState
 }
 

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -286,7 +286,7 @@ const getProjectsLatestProposal = (proposalStandings) => {
   for (const [key, value] of Object.entries(proposalStandings)) {
     latestProposals[key] = value[value.length - 1]
     if (getProjectStandingStatus(value) === ProjectStandingsStatus.Bad)
-      latestProposals[key].fields['Proposal State'] = State.Rejected
+      latestProposals[key].fields['Bad Status'] = true
   }
 
   return latestProposals
@@ -314,9 +314,9 @@ const updateCurrentRoundStandings = (
   for (const [key, value] of Object.entries(currentRoundProposals)) {
     const latestProposal = latestProposals[key]
     if (latestProposal !== undefined) {
-      if (value[0].fields['Proposal Standing'] !== Standings.NoOcean) {
-        value[0].fields['Proposal Standing'] =
-          latestProposal.fields['Proposal Standing']
+      if (latestProposal.fields['Bad Status'] === true) {
+        value[0].fields['Proposal Standing'] = Standings.Unreported
+        value[0].fields['Proposal State'] = State.Rejected
         value[0].fields['Outstanding Proposals'] =
           latestProposal.fields['Outstanding Proposals']
       }

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -615,7 +615,7 @@ describe('Process Project Standings', function () {
     await processHistoricalStandings(proposalStandings)
     const latestProposal = getProjectsLatestProposal(proposalStandings)
 
-    should.equal(latestProposal.test.fields['Proposal State'], State.Rejected)
+    should.equal(latestProposal.test.fields['Bad Status'], true)
   })
 
   it('Validate "No Ocean" property of "Proposal Standings" does not propagate to next round', async function () {

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -386,7 +386,7 @@ describe('Process Project Standings', function () {
       currentProposalStandings['New Existing Entrant'][0].fields[
         'Proposal State'
       ],
-      undefined
+      State.Accepted
     )
     should.equal(
       currentProposalStandings['New Entrant'][0].fields['Proposal Standing'],
@@ -394,7 +394,7 @@ describe('Process Project Standings', function () {
     )
     should.equal(
       currentProposalStandings['New Entrant'][0].fields['Proposal State'],
-      undefined
+      State.Accepted
     )
   })
 


### PR DESCRIPTION
Fixes #79 #78 #77

Changes proposed in this PR:

- If the proposal state is `undefined`:
  - If the wallet has enough tokens set `Proposal State` to `Accepted`.
  - Otherwise set it to `Rejected`.

https://github.com/oceanprotocol/DAOBot/blob/e25e60294a90fa5d709ce228d002ed436949a724/src/airtable/proposals/proposal_standings.js#L75-L87
- If a proposal has bad status set the `Bad Status` field to `true`. 

https://github.com/oceanprotocol/DAOBot/blob/e25e60294a90fa5d709ce228d002ed436949a724/src/airtable/proposals/proposal_standings.js#L284-L290
- If the project's latest proposal has the `Bad Status` field set to true, set the newest proposal to rejected.

https://github.com/oceanprotocol/DAOBot/blob/7a9c21d15e297deb0795a30431c650ffc1c84b64/src/airtable/proposals/proposal_standings.js#L310-L325
- Remove `Bad Status` fields before updating the table.

https://github.com/oceanprotocol/DAOBot/blob/e25e60294a90fa5d709ce228d002ed436949a724/src/airtable/process_airtable_all_proposal_standings.js#L60-L63