### PR TITLE
Fix proposal standings are being set to `New Project`

### DIFF
--- a/src/airtable/process_airtable_all_proposal_standings.js
+++ b/src/airtable/process_airtable_all_proposal_standings.js
@@ -44,7 +44,8 @@ const processAirtableProposalStandings = async (curRoundNumber) => {
     curRoundNumber
   )
   const currentProposalStandings = await processProposalStandings(
-    currentRoundProposals
+    currentRoundProposals,
+    allProposals
   )
   await updateCurrentRoundStandings(
     currentProposalStandings,

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -187,12 +187,15 @@ const getProposalRecord = async (proposal, allProposals) => {
 }
 
 // Returns all Proposal Standings, indexed by Project Name
-const processProposalStandings = async (allProposals) => {
+const processProposalStandings = async (allProposals, extraProposals = []) => {
   const proposalStandings = {}
   for (const proposal of allProposals) {
     try {
       const projectName = proposal.get('Project Name')
-      const record = await getProposalRecord(proposal, allProposals)
+      const record = await getProposalRecord(
+        proposal,
+        allProposals.concat(extraProposals)
+      )
       // Finally, track project standings
       if (proposalStandings[projectName] === undefined)
         proposalStandings[projectName] = []

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -187,14 +187,17 @@ const getProposalRecord = async (proposal, allProposals) => {
 }
 
 // Returns all Proposal Standings, indexed by Project Name
-const processProposalStandings = async (allProposals, extraProposals = []) => {
+const processProposalStandings = async (
+  allProposals,
+  previousProposals = []
+) => {
   const proposalStandings = {}
   for (const proposal of allProposals) {
     try {
       const projectName = proposal.get('Project Name')
       const record = await getProposalRecord(
         proposal,
-        allProposals.concat(extraProposals)
+        allProposals.concat(previousProposals)
       )
       // Finally, track project standings
       if (proposalStandings[projectName] === undefined)


### PR DESCRIPTION
Fixes #81.

Changes proposed in this PR:

- When processing current round proposals we should pass all proposals to the function so it can check whether a former proposal exists for a project.
- Added `extraProposals` optional argument to `processProposalStandings` function. Concatenating the current round proposals with all proposals.