### PR TITLE
Set the state to Funded if the ETH Transaction field is not null

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -72,7 +72,11 @@ const getProjectStanding = (
   return newStanding
 }
 
-const getProposalState = (proposalState, hasEnoughOceans) => {
+const getProposalState = (
+  proposalState,
+  hasEnoughOceans,
+  ethTransactionExists = false
+) => {
   // TODO find a better logic for this
   if (
     hasEnoughOceans &&
@@ -81,6 +85,10 @@ const getProposalState = (proposalState, hasEnoughOceans) => {
     proposalState = State.Accepted
   } else if (proposalState === State.Undefined) {
     proposalState = State.Rejected
+  }
+
+  if (proposalState == State.Accepted && ethTransactionExists) {
+    proposalState = State.Funded
   }
 
   return proposalState

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -150,9 +150,13 @@ const getAllRoundProposals = async (maxRound, minRound = 1) => {
 const getProposalRecord = async (proposal, allProposals) => {
   const proposalURL = proposal.get('Proposal URL')
   const areOceansEnough = await hasEnoughOceans(proposal.get('Wallet Address'))
+  const ethTransactionExists =
+    proposal.get('ETH Transaction') !== null ||
+    proposal.get('ETH Transaction') !== ''
   const proposalState = getProposalState(
     proposal.get('Proposal State'),
-    areOceansEnough
+    areOceansEnough,
+    ethTransactionExists
   )
   const currentStanding = proposal.get('Proposal Standing')
   const deliverableChecklist = proposal.get('Deliverable Checklist') || []

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -87,7 +87,7 @@ const getProposalState = (
     proposalState = State.Rejected
   }
 
-  if (proposalState == State.Accepted && ethTransactionExists) {
+  if (proposalState === State.Accepted && ethTransactionExists) {
     proposalState = State.Funded
   }
 

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -151,7 +151,8 @@ const getProposalRecord = async (proposal, allProposals) => {
   const proposalURL = proposal.get('Proposal URL')
   const areOceansEnough = await hasEnoughOceans(proposal.get('Wallet Address'))
   const ethTransactionExists =
-    proposal.get('ETH Transaction') !== null ||
+    proposal.get('ETH Transaction') !== undefined &&
+    proposal.get('ETH Transaction') !== null &&
     proposal.get('ETH Transaction') !== ''
   const proposalState = getProposalState(
     proposal.get('Proposal State'),

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -598,7 +598,7 @@ describe('Process Project Standings', function () {
     )
     should.equal(
       proposalStandings.test[0].fields['Proposal State'],
-      State.Funded
+      State.Accepted
     )
   })
 

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -598,7 +598,7 @@ describe('Process Project Standings', function () {
     )
     should.equal(
       proposalStandings.test[0].fields['Proposal State'],
-      State.Accepted
+      State.Funded
     )
   })
 


### PR DESCRIPTION
Fixes #87 .

Changes proposed in this PR:

- Added `ethTransactionExists` arg to `getProposalState` function.
- In the `getProposalState` function, set the state to `Funded` if `ethTransactionExists` is `true` and the state is `Accepted`