### PR TITLE
Project Summary doesn't show "OCEAN Granted" column values for some projects

### DIFF
--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -169,9 +169,9 @@ const summarize = (proposals) => {
     if (!project) {
       project = {
         'Project Name': proposal['Project Name'],
-        'Voted Yes': proposal['Voted Yes'],
-        'Voted No': proposal['Voted No'],
-        'OCEAN Granted': proposal['OCEAN Granted'],
+        'Voted Yes': proposal['Voted Yes'] ?? 0,
+        'Voted No': proposal['Voted No'] ?? 0,
+        'OCEAN Granted': proposal['OCEAN Granted'] ?? 0,
         'Times Proposed': 1,
         'Times Granted': proposal['OCEAN Granted'] > 0 ? 1 : 0,
         'Project Standing': {
@@ -185,9 +185,9 @@ const summarize = (proposals) => {
       }
       project['Project Standing'][proposal['Proposal Standing']] += 1
     } else {
-      project['Voted Yes'] += proposal['Voted Yes']
-      project['Voted No'] += proposal['Voted No']
-      project['OCEAN Granted'] += proposal['OCEAN Granted']
+      project['Voted Yes'] += proposal['Voted Yes'] ?? 0
+      project['Voted No'] += proposal['Voted No'] ?? 0
+      project['OCEAN Granted'] += proposal['OCEAN Granted'] ?? 0
       project['Times Granted'] += proposal['OCEAN Granted'] > 0 ? 1 : 0
 
       project['Times Proposed'] += 1


### PR DESCRIPTION
Fixes #35 .

Changes proposed in this PR:

- Set `Voted Yes` `Voted No` `OCEAN Granted` fields to `0` if they are `undefined`.