### PR TITLE
Set proposal state to `Funded` if the state is `Granted` and `ETH Transaction` exists

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -87,7 +87,10 @@ const getProposalState = (
     proposalState = State.Rejected
   }
 
-  if (proposalState === State.Accepted && ethTransactionExists) {
+  if (
+    (proposalState === State.Accepted || proposalState === State.Granted) &&
+    ethTransactionExists
+  ) {
     proposalState = State.Funded
   }
 


### PR DESCRIPTION
Fixes #101 .

Changes proposed in this PR:

- Set proposal state to `Funded` if the state is `Granted` and `ETH Transaction` exists