### PR TITLE
Feature/103 remove windows and mac os devices from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16]
+        node: [14]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         node: [14, 16]
 
     steps:


### PR DESCRIPTION
Fixes #103  .

Changes proposed in this PR:

- Removed macOS and Windows from the workflow.
- Removed Node version 16. Running the tests with Node version 14 is sufficient.