### PR TITLE
Only check ocean balances for the current round

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -232,21 +232,7 @@ const processHistoricalStandings = async (proposalStandings) => {
     let outstandingURL = ''
     let lastStanding
     for (const proposal of value) {
-      const areOceansEnough = await hasEnoughOceans(
-        proposal.fields['Wallet Address']
-      )
       proposal.fields['Outstanding Proposals'] = ''
-      if (proposal.fields['Proposal Standing'] === Standings.NoOcean) {
-        if (areOceansEnough) {
-          proposal.fields['Proposal State'] = State.Accepted
-          proposal.fields['Proposal Standing'] = !projectHasCompletedProposals(
-            proposal,
-            value
-          )
-            ? Standings.NewProject
-            : Standings.Unreported
-        }
-      }
 
       // DISPUTES: If a proposal is under dispute, the project standing becomes poor
       // INCOMPLETION: If a proposal is incomplete/timedout, the project standing becomes poor

--- a/src/snapshot/snapshot_utils.js
+++ b/src/snapshot/snapshot_utils.js
@@ -34,6 +34,7 @@ const hasEnoughOceans = async (wallet_address) => {
   try {
     balance = await getWalletBalance(wallet_address)
   } catch (error) {
+    Logger.error(error)
     return false
   }
   return balance >= MIN_OCEAN_REQUIRED

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -386,10 +386,10 @@ describe('Process Project Standings', function () {
       Standings.Progress
     )
     expect(proposalStandings.project[2].fields['Proposal Standing']).to.equal(
-      Standings.Unreported
+      Standings.NoOcean
     )
     expect(proposalStandings.project[3].fields['Proposal Standing']).to.equal(
-      Standings.NewProject
+      Standings.NoOcean
     )
   })
 


### PR DESCRIPTION
Fixes #106 .

Changes proposed in this PR:

- Removed Ocean balance check from `processHistoricalStandings` function.
- Updated tests accordingly.