### PR TITLE
Update table to report "Max Funding" available based on Funding Tiers

### DIFF
--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -187,7 +187,6 @@ const summarize = (proposals) => {
       }
     }
 
-    project['Project Standing'][proposal['Proposal Standing']] += 1
     project['Voted Yes'] += proposal['Voted Yes'] ?? 0
     project['Voted No'] += proposal['Voted No'] ?? 0
 

--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -130,15 +130,13 @@ const updatedRecordById = async (recordId, dataObject) => {
   }
 }
 
-const levels = {
-  // NOTE: Reference: https://github.com/oceanprotocol/oceandao/wiki#r11-update-funding-levels
-  'Round 11': (project) => {
-    const completed = project['Project Standing'].Completed
-    if (completed === 0) return 'New Project'
-    if (completed === 1) return 'Existing Project'
-    if (completed >= 2 && completed < 5) return 'Experienced Project'
-    if (completed >= 5) return 'Veteran Project'
-  }
+const levels = (completed) => {
+  // NOTE: Reference: https://github.com/oceanprotocol/oceandao/wiki#r12-update-funding-tiers
+  if (completed === 0) return { level: 'New Project', ceiling: 3000 }
+  if (completed === 1) return { level: 'Existing Project', ceiling: 10000 }
+  if (completed >= 2 && completed < 5)
+    return { level: 'Experienced Project', ceiling: 20000 }
+  if (completed >= 5) return { level: 'Veteran Project', ceiling: 35000 }
 }
 
 const toAirtableList = (projects) => {
@@ -146,7 +144,9 @@ const toAirtableList = (projects) => {
 
   for (const [key, value] of Object.entries(projects)) {
     value.ProjectId = key
-    value['Project Level'] = levels['Round 11'](value)
+    const { level, ceiling } = levels(value['Project Standing'].Completed)
+    value['Project Level'] = level
+    value['Max Funding'] = ceiling
     delete value['Project Standing']
 
     airtableList.push({

--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -169,11 +169,13 @@ const summarize = (proposals) => {
     if (!project) {
       project = {
         'Project Name': proposal['Project Name'],
-        'Voted Yes': proposal['Voted Yes'] ?? 0,
-        'Voted No': proposal['Voted No'] ?? 0,
-        'OCEAN Granted': proposal['OCEAN Granted'] ?? 0,
-        'Times Proposed': 1,
-        'Times Granted': proposal['OCEAN Granted'] > 0 ? 1 : 0,
+        'Voted Yes': 0,
+        'Voted No': 0,
+        'Grants Proposed': 0,
+        'Grants Received': 0,
+        'Total Ocean Granted': 0,
+        'Total USD Granted': 0,
+        'Grants Completed': 0,
         'Project Standing': {
           Completed: 0,
           'Funds Returned': 0,
@@ -183,16 +185,21 @@ const summarize = (proposals) => {
           'In Dispute': 0
         }
       }
-      project['Project Standing'][proposal['Proposal Standing']] += 1
-    } else {
-      project['Voted Yes'] += proposal['Voted Yes'] ?? 0
-      project['Voted No'] += proposal['Voted No'] ?? 0
-      project['OCEAN Granted'] += proposal['OCEAN Granted'] ?? 0
-      project['Times Granted'] += proposal['OCEAN Granted'] > 0 ? 1 : 0
-
-      project['Times Proposed'] += 1
-      project['Project Standing'][proposal['Proposal Standing']] += 1
     }
+
+    project['Project Standing'][proposal['Proposal Standing']] += 1
+    project['Voted Yes'] += proposal['Voted Yes'] ?? 0
+    project['Voted No'] += proposal['Voted No'] ?? 0
+
+    project['Total Ocean Granted'] += proposal['OCEAN Granted'] ?? 0
+    project['Total USD Granted'] += proposal['USD Granted'] ?? 0
+
+    project['Grants Received'] += proposal['OCEAN Granted'] > 0 ? 1 : 0
+    project['Grants Completed'] +=
+      proposal['Proposal Standing'] === Standings.Completed ? 1 : 0
+
+    project['Grants Proposed'] += 1
+    project['Project Standing'][proposal['Proposal Standing']] += 1
     projects[proposalUUID] = project
   }
 

--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -173,9 +173,9 @@ const summarize = (proposals) => {
         'Voted No': 0,
         'Grants Proposed': 0,
         'Grants Received': 0,
+        'Grants Completed': 0,
         'Total Ocean Granted': 0,
         'Total USD Granted': 0,
-        'Grants Completed': 0,
         'Project Standing': {
           Completed: 0,
           'Funds Returned': 0,

--- a/src/airtable/project_summary.js
+++ b/src/airtable/project_summary.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const process = require('process')
 const Airtable = require('airtable')
 const { v4: uuidv4 } = require('uuid')
-
+const { Standings } = require('./proposals/proposal_standings')
 const { AIRTABLE_API_KEY, AIRTABLE_BASEID } = process.env
 const base = new Airtable({ apiKey: AIRTABLE_API_KEY }).base(AIRTABLE_BASEID)
 

--- a/src/test/airtable/test_project_summary.test.js
+++ b/src/test/airtable/test_project_summary.test.js
@@ -28,8 +28,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 3,
         'Voted No': 0,
         'OCEAN Granted': 3,
-        'Times Proposed': 2,
-        'Times Granted': 2
+        'Grants Proposed': 2,
+        'Grants Received': 2
       }
     }
     const [id] = await populate([record])
@@ -45,8 +45,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 3,
         'Voted No': 0,
         'OCEAN Granted': 3,
-        'Times Proposed': 2,
-        'Times Granted': 2
+        'Grants Proposed': 2,
+        'Grants Received': 2
       }
     }
     const [id] = await populate([record])
@@ -66,8 +66,8 @@ describe('Creating project summaries', () => {
           'Voted Yes': 3,
           'Voted No': 0,
           'OCEAN Granted': 3,
-          'Times Proposed': 2,
-          'Times Granted': 2
+          'Grants Proposed': 2,
+          'Grants Received': 2
         }
       },
       {
@@ -78,8 +78,8 @@ describe('Creating project summaries', () => {
           'Voted Yes': 0,
           'Voted No': 1,
           'OCEAN Granted': 0,
-          'Times Proposed': 1,
-          'Times Granted': 0
+          'Grants Proposed': 1,
+          'Grants Received': 0
         }
       }
     ]
@@ -156,8 +156,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 3,
         'Voted No': 0,
         'OCEAN Granted': 3,
-        'Times Proposed': 2,
-        'Times Granted': 2
+        'Grants Proposed': 2,
+        'Grants Received': 2
       }
     }
     const [id] = await populate([record])
@@ -189,8 +189,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 3,
         'Voted No': 0,
         'OCEAN Granted': 3,
-        'Times Proposed': 2,
-        'Times Granted': 2,
+        'Grants Proposed': 2,
+        'Grants Received': 2,
         'Project Standing': {
           Completed: 2,
           'Funds Returned': 0,
@@ -205,8 +205,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 0,
         'Voted No': 1,
         'OCEAN Granted': 0,
-        'Times Proposed': 1,
-        'Times Granted': 0,
+        'Grants Proposed': 1,
+        'Grants Received': 0,
         'Project Standing': {
           Completed: 0,
           'Funds Returned': 0,
@@ -226,8 +226,8 @@ describe('Creating project summaries', () => {
           'Voted Yes': 3,
           'Voted No': 0,
           'OCEAN Granted': 3,
-          'Times Proposed': 2,
-          'Times Granted': 2
+          'Grants Proposed': 2,
+          'Grants Received': 2
         }
       },
       {
@@ -238,8 +238,8 @@ describe('Creating project summaries', () => {
           'Voted Yes': 0,
           'Voted No': 1,
           'OCEAN Granted': 0,
-          'Times Proposed': 1,
-          'Times Granted': 0
+          'Grants Proposed': 1,
+          'Grants Received': 0
         }
       }
     ])
@@ -283,8 +283,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 3,
         'Voted No': 0,
         'OCEAN Granted': 3,
-        'Times Proposed': 2,
-        'Times Granted': 2,
+        'Grants Proposed': 2,
+        'Grants Received': 2,
         'Project Standing': {
           Completed: 2,
           'Funds Returned': 0,
@@ -299,8 +299,8 @@ describe('Creating project summaries', () => {
         'Voted Yes': 0,
         'Voted No': 1,
         'OCEAN Granted': 0,
-        'Times Proposed': 1,
-        'Times Granted': 0,
+        'Grants Proposed': 1,
+        'Grants Received': 0,
         'Project Standing': {
           Completed: 0,
           'Funds Returned': 0,

--- a/src/test/airtable/test_project_summary.test.js
+++ b/src/test/airtable/test_project_summary.test.js
@@ -17,39 +17,44 @@ const {
 afterAll(() => {
   jest.clearAllTimers()
 })
-
+const records = [
+  {
+    fields: {
+      ProjectId: '78d91b81-768c-4fef-81c8-07baf3bd72e9',
+      'Project Name': 'FantasyFinance',
+      'Project Level': 'Experienced Project',
+      'Voted Yes': 3,
+      'Voted No': 0,
+      'Total Ocean Granted': 0,
+      'Total USD Granted': 0,
+      'Grants Proposed': 2,
+      'Grants Received': 2,
+      'Grants Completed': 1
+    }
+  },
+  {
+    fields: {
+      ProjectId: '7c17baed-327d-44ad-b09b-7fc5314aa143',
+      'Project Name': 'LoserFinance',
+      'Project Level': 'New Project',
+      'Voted Yes': 3,
+      'Voted No': 0,
+      'Total Ocean Granted': 0,
+      'Total USD Granted': 0,
+      'Grants Proposed': 2,
+      'Grants Received': 2,
+      'Grants Completed': 1
+    }
+  }
+]
 describe('Creating project summaries', () => {
   it('should populate a table', async () => {
-    const record = {
-      fields: {
-        ProjectId: '78d91b81-768c-4fef-81c8-07baf3bd72e9',
-        'Project Name': 'FantasyFinance',
-        'Project Level': 'Experienced Project',
-        'Voted Yes': 3,
-        'Voted No': 0,
-        'OCEAN Granted': 3,
-        'Grants Proposed': 2,
-        'Grants Received': 2
-      }
-    }
-    const [id] = await populate([record])
+    const [id] = await populate([records[0]])
     assert(id.startsWith('rec'))
   })
 
   it('should delete records from a table', async () => {
-    const record = {
-      fields: {
-        ProjectId: '78d91b81-768c-4fef-81c8-07baf3bd72e9',
-        'Project Name': 'FantasyFinance',
-        'Project Level': 'Experienced Project',
-        'Voted Yes': 3,
-        'Voted No': 0,
-        'OCEAN Granted': 3,
-        'Grants Proposed': 2,
-        'Grants Received': 2
-      }
-    }
-    const [id] = await populate([record])
+    const [id] = await populate([records[0]])
     assert(id.startsWith('rec'))
 
     const [removedId] = await remove([id])
@@ -57,32 +62,6 @@ describe('Creating project summaries', () => {
   })
 
   it('should delete ALL records from a table', async () => {
-    const records = [
-      {
-        fields: {
-          ProjectId: '78d91b81-768c-4fef-81c8-07baf3bd72e9',
-          'Project Name': 'FantasyFinance',
-          'Project Level': 'Experienced Project',
-          'Voted Yes': 3,
-          'Voted No': 0,
-          'OCEAN Granted': 3,
-          'Grants Proposed': 2,
-          'Grants Received': 2
-        }
-      },
-      {
-        fields: {
-          ProjectId: '7c17baed-327d-44ad-b09b-7fc5314aa143',
-          'Project Name': 'LoserFinance',
-          'Project Level': 'New Project',
-          'Voted Yes': 0,
-          'Voted No': 1,
-          'OCEAN Granted': 0,
-          'Grants Proposed': 1,
-          'Grants Received': 0
-        }
-      }
-    ]
     const [id] = await populate(records)
     assert(id.startsWith('rec'))
 
@@ -92,54 +71,12 @@ describe('Creating project summaries', () => {
   })
 
   it('should summarize levels given the project standings', () => {
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 0
-        }
-      }),
-      'New Project'
-    )
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 1
-        }
-      }),
-      'Existing Project'
-    )
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 2
-        }
-      }),
-      'Experienced Project'
-    )
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 4
-        }
-      }),
-      'Experienced Project'
-    )
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 5
-        }
-      }),
-      'Veteran Project'
-    )
-    assert.deepEqual(
-      levels['Round 11']({
-        'Project Standing': {
-          Completed: 1337
-        }
-      }),
-      'Veteran Project'
-    )
+    assert.deepEqual(levels(0).level, 'New Project')
+    assert.deepEqual(levels(1).level, 'Existing Project')
+    assert.deepEqual(levels(2).level, 'Experienced Project')
+    assert.deepEqual(levels(4).level, 'Experienced Project')
+    assert.deepEqual(levels(5).level, 'Veteran Project')
+    assert.deepEqual(levels(42).level, 'Veteran Project')
   })
 
   it('should chunk any array to a max size of 10', () => {
@@ -148,18 +85,7 @@ describe('Creating project summaries', () => {
   })
 
   it("should return all projects in the 'Project Summary' table", async () => {
-    const record = {
-      fields: {
-        ProjectId: '78d91b81-768c-4fef-81c8-07baf3bd72e9',
-        'Project Name': 'FantasyFinance',
-        'Project Level': 'Experienced Project',
-        'Voted Yes': 3,
-        'Voted No': 0,
-        'OCEAN Granted': 3,
-        'Grants Proposed': 2,
-        'Grants Received': 2
-      }
-    }
+    const record = records[0]
     const [id] = await populate([record])
     assert(id.startsWith('rec'))
 
@@ -227,7 +153,8 @@ describe('Creating project summaries', () => {
           'Voted No': 0,
           'OCEAN Granted': 3,
           'Grants Proposed': 2,
-          'Grants Received': 2
+          'Grants Received': 2,
+          'Max Funding': 20000
         }
       },
       {
@@ -239,7 +166,8 @@ describe('Creating project summaries', () => {
           'Voted No': 1,
           'OCEAN Granted': 0,
           'Grants Proposed': 1,
-          'Grants Received': 0
+          'Grants Received': 0,
+          'Max Funding': 3000
         }
       }
     ])
@@ -252,6 +180,7 @@ describe('Creating project summaries', () => {
         'Proposal Standing': 'Completed',
         RecordId: 'recJrtD0e7KQH19RG',
         'OCEAN Granted': 1,
+        'USD Granted': 1,
         'Voted Yes': 1,
         'Voted No': 0,
         UUID: '78d91b81-768c-4fef-81c8-07baf3bd72e9'
@@ -261,6 +190,7 @@ describe('Creating project summaries', () => {
         'Proposal Standing': 'Completed',
         RecordId: 'recJrtD0e7KQH19RG',
         'OCEAN Granted': 2,
+        'USD Granted': 2,
         'Voted Yes': 2,
         'Voted No': 0,
         UUID: '78d91b81-768c-4fef-81c8-07baf3bd72e9'
@@ -280,9 +210,11 @@ describe('Creating project summaries', () => {
     expect(summary).to.eql({
       '78d91b81-768c-4fef-81c8-07baf3bd72e9': {
         'Project Name': 'FantasyFinance',
+        'Grants Completed': 2,
         'Voted Yes': 3,
         'Voted No': 0,
-        'OCEAN Granted': 3,
+        'Total Ocean Granted': 3,
+        'Total USD Granted': 3,
         'Grants Proposed': 2,
         'Grants Received': 2,
         'Project Standing': {
@@ -298,7 +230,9 @@ describe('Creating project summaries', () => {
         'Project Name': 'LoserFinance',
         'Voted Yes': 0,
         'Voted No': 1,
-        'OCEAN Granted': 0,
+        'Total Ocean Granted': 0,
+        'Total USD Granted': 0,
+        'Grants Completed': 0,
         'Grants Proposed': 1,
         'Grants Received': 0,
         'Project Standing': {


### PR DESCRIPTION
Fixes #96 .

#### Changes proposed in this PR:

- Rename "Times Proposed", "Times Granted" => "Grants Proposed", "Grants Received"
- Implement "Total Ocean Granted", "Total USD Granted" metrics
- Add "Grants Completed" and "Max Funding' fields

#### Required changes:
- Project summary table: 
  - Rename "Times Proposed", "Times Granted" => "Grants Proposed", "Grants Received".
  - Remove "OCEAN Granted" field.
  - Add  "Max Funding". "Total Ocean Granted", "Total USD Granted", "Grants Completed" fields.
