### PR TITLE
Add proposal validation

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -170,9 +170,9 @@ const validateProposal = (proposal, level) => {
   if (isn(proposal.get('Country of Recipient')))
     return 'Missing Country of Recipient'
 
-  if (isn(proposal.get('Project Email Address'))) return 'Missing Login Email'
+  if (isn(proposal.get('Project Email Address'))) return 'Missing Email Address'
   if (verifyEmail(proposal.get('Project Email Address')) === false)
-    return 'Invalid Login Email'
+    return 'Invalid Email Address'
 
   return true
 }

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -162,9 +162,6 @@ const validateProposal = (proposal, level) => {
   if (isn(proposal.get('Proposal URL'))) return 'Missing Proposal URL'
   if (isn(proposal.get('Grant Deliverables')))
     return 'Missing Grant Deliverables'
-  // if (isn(proposal.get('Voting Starts'))) return 'Missing Voting Starts'
-  // if (isn(proposal.get('Voting Ends'))) return 'Missing Voting Ends'
-  // if (isn(proposal.get('Snapshot Block'))) return 'Missing Snapshot Block'
   if (isn(proposal.get('Project Lead Full Name')))
     return 'Missing Project Lead Full Name'
   if (isn(proposal.get('Country of Recipient')))

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -1,6 +1,8 @@
 const { getProposalsSelectQuery } = require('../airtable_utils')
 const { hasEnoughOceans } = require('../../snapshot/snapshot_utils')
 const Logger = require('../../utils/logger')
+const { levels } = require('../project_summary')
+const { verifyEmail } = require('../../functions/utils')
 
 // Proposal States
 const State = {
@@ -150,18 +152,52 @@ const getAllRoundProposals = async (maxRound, minRound = 1) => {
   return allProposals
 }
 
+const validateProposal = (proposal, level) => {
+  if (proposal.get('Round') < 13) return true
+  const isn = (x) => x == null || x === ''
+  if (proposal.get('USD Requested') > level.ceiling)
+    return 'Invalid USD Requested'
+
+  if (isn(proposal.get('One Liner'))) return 'Missing One Liner'
+  if (isn(proposal.get('Proposal URL'))) return 'Missing Proposal URL'
+  if (isn(proposal.get('Grant Deliverables')))
+    return 'Missing Grant Deliverables'
+  // if (isn(proposal.get('Voting Starts'))) return 'Missing Voting Starts'
+  // if (isn(proposal.get('Voting Ends'))) return 'Missing Voting Ends'
+  // if (isn(proposal.get('Snapshot Block'))) return 'Missing Snapshot Block'
+  if (isn(proposal.get('Project Lead Full Name')))
+    return 'Missing Project Lead Full Name'
+  if (isn(proposal.get('Country of Recipient')))
+    return 'Missing Country of Recipient'
+
+  if (isn(proposal.get('Project Email Address'))) return 'Missing Login Email'
+  if (verifyEmail(proposal.get('Project Email Address')) === false)
+    return 'Invalid Login Email'
+
+  return true
+}
+
 const getProposalRecord = async (proposal, allProposals) => {
+  const completedProposals = allProposals.filter(
+    (x) =>
+      x.get('Proposal Standing') === Standings.Completed &&
+      x.get('Project Name') === proposal.get('Project Name')
+  ).length
+  const level = levels(completedProposals)
   const proposalURL = proposal.get('Proposal URL')
   const areOceansEnough = await hasEnoughOceans(proposal.get('Wallet Address'))
   const ethTransactionExists =
     proposal.get('ETH Transaction') !== undefined &&
     proposal.get('ETH Transaction') !== null &&
     proposal.get('ETH Transaction') !== ''
-  const proposalState = getProposalState(
+  let proposalState = getProposalState(
     proposal.get('Proposal State'),
     areOceansEnough,
     ethTransactionExists
   )
+  const validProposal = validateProposal(proposal, level)
+  if (validProposal !== true) proposalState = State.Rejected // Set the proposal state to rejected if the proposal is not valid
+
   const currentStanding = proposal.get('Proposal Standing')
   const deliverableChecklist = proposal.get('Deliverable Checklist') || []
   const deliverableUpdate = proposal.get('Last Deliverable Update')
@@ -197,7 +233,8 @@ const getProposalRecord = async (proposal, allProposals) => {
       'Proposal State': proposalState,
       'Proposal Standing': newStanding,
       'Disputed Status': disputed,
-      'Outstanding Proposals': undefined
+      'Outstanding Proposals': undefined,
+      'Reason Rejected': validProposal === true ? undefined : validProposal
     }
   }
 }

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -384,5 +384,6 @@ module.exports = {
   getProjectsLatestProposal,
   updateCurrentRoundStandings,
   projectHasCompletedProposals,
-  getProposalState
+  getProposalState,
+  validateProposal
 }

--- a/src/functions/utils.js
+++ b/src/functions/utils.js
@@ -8,8 +8,17 @@ async function sleep(ms) {
   await _sleep(ms)
 }
 
+function verifyEmail(email) {
+  email = String(email).toLowerCase().trim()
+  if (email.length === 0) {
+    return false
+  }
+  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return re.test(email)
+}
+
 function _sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-module.exports = { assert, sleep }
+module.exports = { assert, sleep, verifyEmail }

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -11,52 +11,12 @@ const {
   buildBatchProposalPayload,
   local_broadcast_proposal
 } = require('./snapshot_utils')
-const { assert, sleep } = require('../functions/utils')
 const { web3 } = require('../functions/web3')
 
 const pk = process.env.ETH_PRIVATE_KEY || 'your_key_here'
 const account = web3.eth.accounts.privateKeyToAccount(pk)
 web3.eth.accounts.wallet.add(account)
 web3.eth.defaultAccount = account.address
-
-const validateAccceptedProposal = (proposal) => {
-  assert(
-    proposal.get('One Liner') !== undefined,
-    '[%s][%s]: Invalid <One Liner>',
-    proposal.id,
-    proposal.get('Name')
-  )
-  assert(
-    proposal.get('Proposal URL') !== undefined,
-    '[%s][%s]: Invalid <Proposal URL>',
-    proposal.id,
-    proposal.get('Name')
-  )
-  assert(
-    proposal.get('Grant Deliverables') !== undefined,
-    '[%s][%s]: Invalid <Grant Deliverables>',
-    proposal.id,
-    proposal.get('Name')
-  )
-  assert(
-    proposal.get('Voting Starts') !== undefined,
-    '[%s][%s]: Invalid <Voting Starts>',
-    proposal.id,
-    proposal.get('Name')
-  )
-  assert(
-    proposal.get('Voting Ends') !== undefined,
-    '[%s][%s]: Invalid <Voting Ends>',
-    proposal.id,
-    proposal.get('Name')
-  )
-  assert(
-    proposal.get('Snapshot Block') !== undefined,
-    '[%s][%s]: Invalid <Snapshot Block>',
-    proposal.id,
-    proposal.get('Name')
-  )
-}
 
 // All required fields should have already been validated by the online Form
 // Build payload for proposal, and submit it
@@ -72,8 +32,6 @@ const submitProposalsToSnaphotGranular = async (roundNumber, voteType) => {
     // We probably want to throttle the deployment to snapshot w/ a sleep
     const submittedProposals = []
     for (const proposal of acceptedProposals) {
-      validateAccceptedProposal(proposal)
-
       const payload = buildGranularProposalPayload(
         proposal,
         roundNumber,
@@ -131,7 +89,6 @@ const submitProposalsToSnaphotBatch = async (roundNumber, voteType) => {
     let index = 1
 
     for (const proposal of acceptedProposals) {
-      validateAccceptedProposal(proposal)
       proposalIndex[proposal.get('Project Name')] = [index, index + 1]
       proposalArr.push(proposal.get('Project Name') + '_Yes')
       proposalArr.push(proposal.get('Project Name') + '_No')

--- a/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
+++ b/src/snapshot/submit_snapshot_accepted_proposals_airtable.js
@@ -11,6 +11,7 @@ const {
   buildBatchProposalPayload,
   local_broadcast_proposal
 } = require('./snapshot_utils')
+const { sleep } = require('../functions/utils')
 const { web3 } = require('../functions/web3')
 
 const pk = process.env.ETH_PRIVATE_KEY || 'your_key_here'

--- a/src/test/airtable/test_airtable_proposal_standings.test.js
+++ b/src/test/airtable/test_airtable_proposal_standings.test.js
@@ -36,7 +36,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'May 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -53,7 +59,13 @@ beforeEach(async function () {
         'Last Deliverable Update': undefined,
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -70,7 +82,13 @@ beforeEach(async function () {
         'Last Deliverable Update': undefined,
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -90,7 +108,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Jan 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -107,7 +131,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Feb 01, 2021',
         'Refund Transaction': '0xRefundTx',
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -124,7 +154,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Mar 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -141,7 +177,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Mar 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_NOT_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_NOT_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -158,7 +200,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Jan 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -175,7 +223,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Apr 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -192,7 +246,13 @@ beforeEach(async function () {
         'Last Deliverable Update': 'Apr 01, 2021',
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]
@@ -210,7 +270,13 @@ beforeEach(async function () {
         'Refund Transaction': undefined,
         'Disputed Status': undefined,
         'Deployment Ready': 'Yes',
-        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS
+        'Wallet Address': WALLET_ADDRESS_WITH_ENOUGH_OCEANS,
+        'One Liner': 'adasd',
+        'Grant Deliverables': 'asdasd',
+        'Project Lead Full Name': 'John Doe',
+        'Country of Recipient': 'country',
+        'Project Email Address': 'valid@email.yes',
+        'USD Requested': 0
       },
       get: function (key) {
         return this.fields[key]


### PR DESCRIPTION
Fixes #112.

Changes proposed in this PR:

- Removed `assert` validations from `submit_snapshot_accepted_proposals_airtable.js` file.
- If a proposal is not valid, DAOBot will set the state to rejected and update the `Reason Rejected` field.
- Added validations for:
  - `One Liner` field is not empty.
  - `Proposal URL` field is not empty.
  - `Grant Deliverables` field is not empty.
  - `Project Lead Full Name` field is not empty.
  - `Country of Recipient` field is not empty.
  - The email address is not empty and **valid**.
  - **The requested USD amount is valid (not over the maximum amount)**
- Added `verifyEmail` function.

Things to do before merging this PR:
- **Add `Reason Rejected` field to the production table**