### PR TITLE
Move ocean -> usd calculation to voting period ends

### DIFF
--- a/src/airtable/airtable_utils.js
+++ b/src/airtable/airtable_utils.js
@@ -90,23 +90,35 @@ const updateProposalRecords = async (records) => {
 }
 
 const updateRoundRecord = async (record) => {
-  await fetch(
-    `https://api.airtable.com/v0/${process.env.AIRTABLE_BASEID}/Funding Rounds`,
-    {
-      method: 'patch', // make sure it is a "PATCH request"
-      headers: {
-        Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`, // API key
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ records: record })
-    }
-  )
-    .then((res) => {
-      Logger.log('Response from Airtable: ', res.status)
-    })
-    .catch((err) => {
-      Logger.error(err)
-    })
+  return new Promise((resolve, reject) => {
+    fetch(
+      `https://api.airtable.com/v0/${process.env.AIRTABLE_BASEID}/Funding Rounds`,
+      {
+        method: 'patch', // make sure it is a "PATCH request"
+        headers: {
+          Authorization: `Bearer ${process.env.AIRTABLE_API_KEY}`, // API key
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ records: record })
+      }
+    )
+      .then((res) => {
+        Logger.log('Response from Airtable: ', res.status)
+        return res.json()
+      })
+      .then((res) => {
+        if (res.error) {
+          Logger.error(res.error)
+          reject(res.error)
+        }
+        Logger.log(res)
+        resolve(res)
+      })
+      .catch((err) => {
+        Logger.error(err)
+        reject(err)
+      })
+  })
 }
 
 module.exports = {

--- a/src/functions/chainlink.js
+++ b/src/functions/chainlink.js
@@ -3,6 +3,7 @@ const aggregatorV3InterfaceABI = require('./../utils/aggregatorV3InterfaceABI.js
 const OceanUsdDataFeedContractAddress =
   '0x7ece4e4E206eD913D991a074A19C192142726797'
 const Logger = require('../utils/logger')
+const { getTokenPrice: coingeckoGetTokenPrice } = require('./coingecko')
 
 const getTokenPrice = async () => {
   try {
@@ -16,6 +17,7 @@ const getTokenPrice = async () => {
     return price
   } catch (error) {
     Logger.error(error)
+    return await coingeckoGetTokenPrice()
   }
 }
 

--- a/src/functions/coingecko.js
+++ b/src/functions/coingecko.js
@@ -20,6 +20,7 @@ const getTokenPrice = async () => {
     return result.data.market_data.current_price.usd
   } catch (err) {
     Logger.error(err)
+    throw Error(`Error getting token price: ${err}`)
   }
 }
 

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -133,7 +133,15 @@ const main = async () => {
         lastRoundNumber,
         lastRoundBallotType
       )
-      await syncGSheetsActiveProposalVotes(lastRoundNumber, lastRoundBallotType)
+
+      try {
+        await syncGSheetsActiveProposalVotes(
+          lastRoundNumber,
+          lastRoundBallotType
+        )
+      } catch (err) {
+        Logger.error(`Error syncing GSheets Active Proposal Votes: ${err}`)
+      }
 
       // Complete round calculations
       const proposalsFunded = await processFundingRoundComplete(

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -118,7 +118,8 @@ const main = async () => {
       ) // calculate the earmark values based on the updated Ocean price
       const roundUpdateData = {
         'OCEAN Price': oceanPrice,
-        Earmarks: JSON.stringify(earmarkStructure)
+        Earmarks: JSON.stringify(earmarkStructure),
+        'Funding Available USD': lastRound.get('Funding Available') * oceanPrice
       }
 
       await lastRound.updateFields(roundUpdateData) // update the round record

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -117,14 +117,11 @@ const main = async () => {
         lastRound.get('Basis Currency')
       ) // calculate the earmark values based on the updated Ocean price
       const roundUpdateData = {
-        // create the data to update the round record
-        id: lastRound.id,
-        fields: {
-          'OCEAN Price': oceanPrice,
-          Earmarks: JSON.stringify(earmarkStructure)
-        }
+        'OCEAN Price': oceanPrice,
+        Earmarks: JSON.stringify(earmarkStructure)
       }
-      await updateRoundRecord(roundUpdateData) // update the round record
+
+      await lastRound.updateFields(roundUpdateData) // update the round record
 
       Logger.log('Start next round.')
       // Update votes and compute funds burned

--- a/src/scripts/update_funding_round.js
+++ b/src/scripts/update_funding_round.js
@@ -110,6 +110,22 @@ const main = async () => {
   if (curRoundState === undefined) {
     // this is when the round is ending => switching to the next funding round
     if (lastRoundState === RoundState.Voting && now >= lastRoundVoteEnd) {
+      const oceanPrice = await getTokenPrice() // get the latest Ocean price
+      const earmarkStructure = await completeEarstructuresValues(
+        lastRound,
+        oceanPrice,
+        lastRound.get('Basis Currency')
+      ) // calculate the earmark values based on the updated Ocean price
+      const roundUpdateData = {
+        // create the data to update the round record
+        id: lastRound.id,
+        fields: {
+          'OCEAN Price': oceanPrice,
+          Earmarks: JSON.stringify(earmarkStructure)
+        }
+      }
+      await updateRoundRecord(roundUpdateData) // update the round record
+
       Logger.log('Start next round.')
       // Update votes and compute funds burned
       const fundsBurned = await computeBurnedFunds(lastRound, lastRoundNumber)


### PR DESCRIPTION
Fixes #121.

Changes proposed in this PR:

- Get the latest Ocean price when the voting period ends.
- Recalculate the earmark structures with the latest Ocean price and update it in Airtable.
- Update the 'Ocean Price' field for that round in Airtable.
- Try to get the Ocean price from the Chainlink oracle, if that fails; try to get it using Coingecko API, if that fails; throw.