### PR TITLE
Fix USD calculations & improve code readability

### DIFF
--- a/src/airtable/rounds/funding_rounds.js
+++ b/src/airtable/rounds/funding_rounds.js
@@ -135,26 +135,26 @@ const calculateWinningProposalsForEarmark = (
         oceanRequested = Math.ceil(usdRequested / oceanPrice)
       }
 
-      const grantCarry = p.get('USD Granted') || 0
-      let usdGranted =
-        fundsLeft -
-          Math.ceil((usdRequested - grantCarry) / oceanPrice) * oceanPrice >
-        0
-          ? usdRequested - grantCarry
-          : fundsLeft
-      const oceanGranted =
-        usdGranted === fundsLeft
-          ? Math.floor((usdGranted + grantCarry) / oceanPrice)
-          : Math.ceil((usdGranted + grantCarry) / oceanPrice)
-      usdGranted = oceanGranted * oceanPrice
+      const grantCarry = p.get('USD Granted') || 0 // USD granted from previous earmaks
+      const usdRequestedLeft =
+        Math.ceil((usdRequested - grantCarry) / oceanPrice) * oceanPrice
+
+      const canFullGrant = fundsLeft - usdRequestedLeft > 0 // Whether we can grant the full amount
+
+      const usdGranted = canFullGrant ? usdRequestedLeft : fundsLeft
+      const totalUsdGranted = usdGranted + grantCarry
+
+      const oceanGranted = !canFullGrant
+        ? Math.floor(totalUsdGranted / oceanPrice)
+        : Math.ceil(totalUsdGranted / oceanPrice)
 
       p.fields['OCEAN Requested'] = oceanRequested
       p.fields['USD Requested'] = usdRequested
-      p.fields['USD Granted'] = usdGranted + grantCarry
+      p.fields['USD Granted'] = oceanGranted * oceanPrice
       p.fields['OCEAN Granted'] = oceanGranted
       p.fields['Proposal State'] = 'Granted'
       fundsLeft =
-        fundsLeft - usdGranted < 0 ? fundsLeft : fundsLeft - usdGranted
+        fundsLeft - usdGranted <= 0 ? fundsLeft : fundsLeft - usdGranted
 
       // If we reached the total, then it won via this grant pot
       if (usdRequested <= usdGranted + grantCarry) winningProposals.push(p)

--- a/src/test/airtable/test_airtable_round_winners.test.js
+++ b/src/test/airtable/test_airtable_round_winners.test.js
@@ -265,12 +265,10 @@ describe('Calculating Winners', function () {
     const winningProposals = getWinningProposals(allProposals, fundingRound)
     const finalResults = calculateFinalResults(winningProposals, fundingRound)
 
-    Logger.log(finalResults)
-
     // Validate all winning, not funded, and downvoted proposals add up
-    should.equal(finalResults.earmarkedResults.winningProposals.length, 4)
+    should.equal(finalResults.earmarkedResults.winningProposals.length, 5)
     should.equal(finalResults.partiallyFunded.length, 1)
-    should.equal(finalResults.notFunded.length, 1)
+    should.equal(finalResults.notFunded.length, 0)
 
     should.equal(
       finalResults.earmarkedResults.winningProposals.length +
@@ -291,10 +289,7 @@ describe('Calculating Winners', function () {
       finalResults.partiallyFunded[0].fields['Proposal State'],
       'Granted'
     )
-    should.equal(
-      finalResults.notFunded[0].fields['Proposal State'],
-      'Not Granted'
-    )
+
     should.equal(downvotedProposals[0].fields['Proposal State'], 'Down Voted')
 
     // Validate USD amount adds up
@@ -310,7 +305,7 @@ describe('Calculating Winners', function () {
 
     Logger.log(earmarkedUSDGranted, partialUSDGranted)
 
-    should.equal(earmarkedUSDGranted + partialUSDGranted, 35000)
+    should.equal(earmarkedUSDGranted + partialUSDGranted, 36000)
   })
 
   it('Validates gsheet output is correct.', async function () {
@@ -424,6 +419,7 @@ describe('Calculating Winners', function () {
   })
 
   it('Check if funds left from earmaks are burned if burn switch selected', async function () {
+    fundingRound.fields['OCEAN Price'] = 0.2
     const oceanPrice = fundingRound.get('OCEAN Price')
     fundingRound.fields['Basis Token'] = 'OCEAN'
     fundingRound.fields['Funds Left'] = 'Burn'
@@ -436,6 +432,7 @@ describe('Calculating Winners', function () {
       basisToken
     )
     fundingRound.fields.Earmarks = JSON.stringify(newEarmarks)
+
     // set earmarks for proposals and add USD Granted
     allProposals[0].fields.Earmarks = Earmarks.NEW_OUTREACH
     allProposals[0].fields['USD Requested'] = 2000


### PR DESCRIPTION
Fixes #120.

Changes proposed in this PR:

- Fix USD calculations.
- Improve code readability.

Cause of the bug:

```js
const oceanGranted =
        usdGranted === fundsLeft
          ? Math.floor((usdGranted + grantCarry) / oceanPrice)
          : Math.ceil((usdGranted + grantCarry) / oceanPrice) // one - usdGranted + grantCarry
usdGranted = oceanGranted * oceanPrice
p.fields['USD Granted'] = usdGranted + grantCarry // two - grantCarry is summed twice
```