### PR TITLE
Fix `Last Balance Check` checks

### DIFF
--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -85,7 +85,10 @@ const getProposalState = (
     (proposalState === State.Rejected || proposalState === State.Undefined)
   ) {
     proposalState = State.Accepted
-  } else if (proposalState === State.Undefined) {
+  } else if (
+    !hasEnoughOceans &&
+    (proposalState === State.Undefined || proposalState === State.Accepted)
+  ) {
     proposalState = State.Rejected
   }
 

--- a/src/airtable/proposals/proposal_standings.js
+++ b/src/airtable/proposals/proposal_standings.js
@@ -185,13 +185,19 @@ const getProposalRecord = async (proposal, allProposals, curRoundNumber) => {
   const proposalURL = proposal.get('Proposal URL')
 
   let lastOceanBalanceCheckDate = proposal.get('Last Balance Check')
-  let areOceansEnough = proposal.get('Proposal Standing') !== 'No Ocean'
+  let areOceansEnough =
+    proposal.get('Proposal Standing') !== '' &&
+    proposal.get('Proposal Standing') !== 'No Ocean'
   if (
-    !(curRoundNumber !== undefined && curRoundNumber !== proposal.get('Round'))
+    !(
+      curRoundNumber !== undefined &&
+      parseInt(curRoundNumber) !== parseInt(proposal.get('Round'))
+    )
   ) {
     if (
       !lastOceanBalanceCheckDate ||
-      new Date(lastOceanBalanceCheckDate) + 1000 * 60 * 15 < new Date() // undefined or 15 minutes has passed
+      new Date(lastOceanBalanceCheckDate).getTime() + 1000 * 60 * 15 <
+        Date.now() // undefined or 15 minutes has passed
     ) {
       areOceansEnough = await hasEnoughOceans(proposal.get('Wallet Address')) // get Ocean balance
       lastOceanBalanceCheckDate = new Date() // update last Ocean balance check date

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -5,6 +5,7 @@ const {
   getProposalsSelectQuery,
   updateProposalRecords
 } = require('../airtable/airtable_utils')
+const { hasEnoughOceans } = require('../snapshot/snapshot_utils')
 const { calcTargetBlockHeight } = require('../snapshot/snapshot_utils')
 const { web3 } = require('../functions/web3')
 const Logger = require('../utils/logger')
@@ -50,6 +51,7 @@ const prepareProposalsForSnapshot = async (curRound) => {
     proposals.map(async (proposal) => {
       getProposalRecord(proposal, proposals)
       try {
+        const wallet_0x = proposal.get('Wallet Address')
         const proposalStanding = proposal.get('Proposal Standing')
 
         // Please update enums as required
@@ -60,7 +62,7 @@ const prepareProposalsForSnapshot = async (curRound) => {
           proposalStanding === Standings.Unreported ||
           proposalStanding === Standings.NewProject
 
-        if (goodStanding === true) {
+        if ((await hasEnoughOceans(wallet_0x)) && goodStanding === true) {
           recordsPayload.push({
             id: proposal.id,
             fields: {

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -5,10 +5,7 @@ const {
   getProposalsSelectQuery,
   updateProposalRecords
 } = require('../airtable/airtable_utils')
-const {
-  calcTargetBlockHeight,
-  hasEnoughOceans
-} = require('../snapshot/snapshot_utils')
+const { calcTargetBlockHeight } = require('../snapshot/snapshot_utils')
 const { web3 } = require('../functions/web3')
 const Logger = require('../utils/logger')
 const {

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -5,8 +5,10 @@ const {
   getProposalsSelectQuery,
   updateProposalRecords
 } = require('../airtable/airtable_utils')
-const { hasEnoughOceans } = require('../snapshot/snapshot_utils')
-const { calcTargetBlockHeight } = require('../snapshot/snapshot_utils')
+const {
+  calcTargetBlockHeight,
+  hasEnoughOceans
+} = require('../snapshot/snapshot_utils')
 const { web3 } = require('../functions/web3')
 const Logger = require('../utils/logger')
 const {

--- a/src/snapshot/prepare_snapshot_received_proposals_airtable.js
+++ b/src/snapshot/prepare_snapshot_received_proposals_airtable.js
@@ -53,7 +53,6 @@ const prepareProposalsForSnapshot = async (curRound) => {
     proposals.map(async (proposal) => {
       getProposalRecord(proposal, proposals)
       try {
-        const wallet_0x = proposal.get('Wallet Address')
         const proposalStanding = proposal.get('Proposal Standing')
 
         // Please update enums as required
@@ -64,7 +63,7 @@ const prepareProposalsForSnapshot = async (curRound) => {
           proposalStanding === Standings.Unreported ||
           proposalStanding === Standings.NewProject
 
-        if ((await hasEnoughOceans(wallet_0x)) && goodStanding === true) {
+        if (goodStanding === true) {
           recordsPayload.push({
             id: proposal.id,
             fields: {


### PR DESCRIPTION
Changes proposed in this PR:

- Fix `Last Balance Check` checks
- Remove balance check in `prepareProposalsForSnapshot` function, this causes the balances to be checked twice. It is called in `prepareNewProposals` function in `update_funding_round.js` file.